### PR TITLE
Use old-school a.href trick to get URL parts

### DIFF
--- a/app/components/human-url.js
+++ b/app/components/human-url.js
@@ -3,11 +3,14 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   parsed: Ember.computed('url', function() {
     if (this.get('url')) {
-      try {
-        return new URL(this.get('url'));
-      } catch (e) {
-        return '';
-      }
+      let a = document.createElement('a');
+
+      a.href = this.get('url');
+
+      let host = a.hostname;
+      let pathname = a.pathname.replace(/^\/?/, '/');
+
+      return { host, pathname };
     }
   }),
   domain: Ember.computed('parsed.host', function() {


### PR DESCRIPTION
The `URL` API is not supported in IE11 and this is the next best thing to a regex (although it still involves some regex).

Why this came up:

I was working with an accessibility developer who was testing with JAWS in IE11. They asked “where do I find out about addons” to which I replied “emberobserver.com” to which *they* replied “it doesn’t seem to link to the projects repos…”.

Before:

![screen shot 2016-05-24 at 16 11 57](https://cloud.githubusercontent.com/assets/34030/15510296/b9ef75e0-21ce-11e6-8afd-d9d1e4683192.png)

After:

![screen shot 2016-05-24 at 16 38 46](https://cloud.githubusercontent.com/assets/34030/15510304/be2d3cdc-21ce-11e6-9658-f36e6fced881.png)
