### PR TITLE
Show addon readmes

### DIFF
--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -16,7 +16,9 @@ export default function() {
 
   this.get('/addons', function(db, request) {
     if (request.queryParams.name) {
-      return { addons: db.addons.where({ name: request.queryParams.name }) };
+      var addons = db.addons.where({ name: request.queryParams.name });
+      var readmes = db.readmes.find(addons.mapBy('readme_id'));
+      return { addon: addons[0], readmes };
     }
 
     let simpleAddonProps = ['id', 'name', 'latest_version_date', 'latest_reviewed_version_date', 'description', 'is_deprecated', 'is_official', 'is_cli_dependency', 'is_hidden', 'score', 'is_wip'];

--- a/app/mirage/factories/addon.js
+++ b/app/mirage/factories/addon.js
@@ -30,5 +30,6 @@ export default Mirage.Factory.extend({
   committed_to_recently: true,
   is_top_starred: false,
   demoUrl: null,
-  is_fully_loaded: true
+  is_fully_loaded: true,
+  readme_id: null
 });

--- a/app/mirage/factories/readme.js
+++ b/app/mirage/factories/readme.js
@@ -1,0 +1,5 @@
+import Mirage, { faker } from 'ember-cli-mirage';
+
+export default Mirage.Factory.extend({
+  contents: () => faker.lorem.paragraph()
+});

--- a/app/models/addon.js
+++ b/app/models/addon.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
-import DS from 'ember-data';
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 import sortBy from '../utils/sort-by';
 
-var attr = DS.attr;
-var hasMany = DS.hasMany;
-
-export default DS.Model.extend({
+export default Model.extend({
   isAddon: true,
   name: attr('string'),
   description: attr('string'),
@@ -42,6 +41,7 @@ export default DS.Model.extend({
   versions: hasMany('version', { async: true }),
   maintainers: hasMany('maintainer', { async: true }),
   reviews: hasMany('review', { async: true }),
+  readme: belongsTo('readme', { async: true }),
   sortedVersions: sortBy('versions', 'released:desc'),
   latestVersion: Ember.computed.alias('sortedVersions.firstObject'),
   oldestVersion: Ember.computed.alias('sortedVersions.lastObject'),

--- a/app/models/readme.js
+++ b/app/models/readme.js
@@ -1,0 +1,6 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+
+export default Model.extend({
+  contents: attr('string')
+});

--- a/app/styles/_addons_show.scss
+++ b/app/styles/_addons_show.scss
@@ -252,4 +252,83 @@
       color: $hover-link-color;
     }
   }
+
+  .readme {
+    border: 1px solid #d8d8d8;
+    border-radius: 3px 3px 0 0;
+    h2, h3, h4, h5 {
+      margin: 24px 0 16px 0;
+      font-weight: bold;
+    }
+    h1, h2 {
+      border-bottom: 1px solid #eee;
+      padding-bottom: .3em;
+    }
+    h1 {
+      font-size: 2rem;
+    }
+    h2 {
+      font-size: 1.5rem;
+    }
+    h3 {
+      font-size: 1.25rem;
+    }
+    h4 {
+      font-size: 1rem;
+    }
+    h5 {
+      font-size: .9rem;
+    }
+    code {
+      background-color: #f7f7f7;
+      padding: .3rem;
+      font-size: 90%;
+    }
+    pre {
+      background-color: #f7f7f7;
+      padding: 16px;
+      overflow: auto;
+      border-radius: 3px;
+      line-height: 1.25rem;
+      code {
+        padding: 0;
+      }
+    }
+    th, td {
+      border: 1px solid #ddd;
+      padding: 6px 13px;
+    }
+    ul, ol {
+      padding-left: 2rem;
+      margin-bottom: 1rem;
+    }
+
+    ul {
+      list-style-type: disc;
+      ul {
+        list-style-type: circle;
+        ul {
+          list-style-type: square;
+        }
+      }
+    }
+    ol {
+      list-style-type: decimal;
+    }
+    .task-list-item input {
+      margin-left: -1.2em !important;
+    }
+    .header {
+      border-bottom: 1px solid #d8d8d8;
+      background-color: #f5f5f5;
+      font-weight: bold;
+      padding: .5rem .75rem;
+      margin-bottom: 0;
+    }
+
+    .contents {
+      padding: 2rem;
+      margin-bottom: 0;
+    }
+  }
 }

--- a/app/templates/addons/show.hbs
+++ b/app/templates/addons/show.hbs
@@ -87,18 +87,20 @@
       {{/if}}
     </section>
 
-    <section class="readme">
-      <p class="header">README.md</p>
-      <p class="test-addon-readme contents">
-        {{markdown-to-html
-          markdown=model.readme.contents
-          tables=true
-          ghCodeBlocks=true
-          tasklists=true
-          simplifiedAutoLink=true
-        }}
-      </p>
-    </section>
+    {{#if model.readme}}
+      <section class="readme">
+        <p class="header">README.md</p>
+        <p class="test-addon-readme contents">
+          {{markdown-to-html
+            markdown=model.readme.contents
+            tables=true
+            ghCodeBlocks=true
+            tasklists=true
+            simplifiedAutoLink=true
+          }}
+        </p>
+      </section>
+    {{/if}}
   </div>
 
   <div class="addon-stats">

--- a/app/templates/addons/show.hbs
+++ b/app/templates/addons/show.hbs
@@ -86,6 +86,19 @@
         <p class="no-review test-no-review">This addon has not yet been reviewed.</p>
       {{/if}}
     </section>
+
+    <section class="readme">
+      <p class="header">README.md</p>
+      <p class="test-addon-readme contents">
+        {{markdown-to-html
+          markdown=model.readme.contents
+          tables=true
+          ghCodeBlocks=true
+          tasklists=true
+          simplifiedAutoLink=true
+        }}
+      </p>
+    </section>
   </div>
 
   <div class="addon-stats">

--- a/app/templates/addons/show.hbs
+++ b/app/templates/addons/show.hbs
@@ -11,7 +11,7 @@
 
       <h1>
         {{#if model.isOfficial}}
-          <span class="icon-stars official test-addon-flag-official" title="Offical Ember-CLI addon"></span>
+          <span class="icon-stars official test-addon-flag-official" title="Official Ember-CLI addon"></span>
         {{/if}}
 
         {{#if model.isCliDependency}}

--- a/tests/acceptance/addons-test.js
+++ b/tests/acceptance/addons-test.js
@@ -337,3 +337,20 @@ test('displays addon stats', function(assert) {
     assert.contains('.test-addon-badge .test-badge-markdown', '[![Ember Observer Score](https://emberobserver.com/badges/test-addon.svg)](https://emberobserver.com/addons/test-addon)');
   });
 });
+
+test('displays readme', function(assert) {
+  var readme = server.create('readme', {
+    contents: 'fudgesicles'
+  });
+
+  var addon = server.create('addon', {
+    name: 'test-addon',
+    readme_id: readme.id
+  });
+
+  visitAddon(addon);
+
+  andThen(() => {
+    assert.contains('.test-addon-readme', readme.contents);
+  });
+});


### PR DESCRIPTION
- Display addon's readme on the show route and make it look pretty

- Guard against missing readme (this can be deployed independently of the server change, and there also are some addons without readmes when I fetch data in development.. let me know if you'd prefer a "readme data unavailable" message instead)

- Make the mirage config return a single addon rather than an array for the queryRecord response. This removes a deprecation warning and matches the real server response

- Fix a minor typo on the addons show route ('Official')
