### PR TITLE
[WIP] Adds opensearch

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -10,6 +10,7 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/ember-addon-review.css">
+    <link rel="search" type="application/opensearchdescription+xml" title="Ember Observer" href="/opensearch.xml" />
 
     {{content-for "snippets/perf-utils"}}
     {{content-for "snippets/favicon"}}

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,8 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+<ShortName>Ember Observer</ShortName>
+<Description>
+</Description>
+<InputEncoding>UTF-8</InputEncoding>
+<Image width="16" height="16" type="image/x-icon">https://emberobserver.com/favicon.ico</Image>
+<Url type="text/html" method="get" template="https://emberobserver.com/?query={searchTerms}"/>
+</OpenSearchDescription>


### PR DESCRIPTION
### What is opensearch?

[Opensearch](http://www.opensearch.org/) is a way to describe a search engine.
This adds the ability to search on Ember observer from the url bar on [most browsers](http://www.opensearch.org/Community/OpenSearch_search_clients).

Developers can take advantage of opensearch to speed up their search for an addon.
#### Current workflow
1. Go to emberobserver.com and wait for SPA to load
2. Type query
3. Find results
#### New/Additional workflow
1. type `emberobserver.com` characters (URL Bar) until you get chrome to autocomplete `emberobser.com` and hit tab
2. type addon name
3. Find results

**Extra notes**
I find it particularly useful when searching on Google, Facebook, Github and many other websites that have opensearch implemented.
Not everyone uses this, but for everyone else that does it makes it super useful.
