### PR TITLE
Fix typo in template for about

### DIFF
--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -12,7 +12,7 @@
 
     <h3>"Reviews"</h3>
     <p>Every addon that is published has been and will be "reviewed", though "evaluated" would perhaps be a better term. The review consists of five questions:</p>
-    <p><em>Is the source accessible?</em> - This one is straightforward: can the source be found? In practice this has turned out to not be a terribly useful question and will probably be removed at somepoint.</p>
+    <p><em>Is the source accessible?</em> - This one is straightforward: can the source be found? In practice this has turned out to not be a terribly useful question and will probably be removed at some point.</p>
     <p><em>Is it more than an empty addon?</em> - Is the addon more than the base generated addon? Another question that turns out to not be very useful. It will probably be removed in favor of hiding addons from the site until they are more than an empty addon.</p>
     <p><em>Are there meaningful tests?</em> - The key word here is "meaningful", in reviewing we took this to mean <em>any</em> tests beyond the tests provided by generators.</p>
     <p><em>Is the README filled out?</em> - Does the README have content that is not the default generated content?</p>


### PR DESCRIPTION
Hi everyone, 

thanks for this repo, I'm learning Ember from it.

Saw a little typo in the text... `somepoint` → `some point`.

Cheers!
Gus