### PR TITLE
Bump ember-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-component-focus": "0.2.2",
     "ember-concurrency": "0.7.8",
-    "ember-data": "^2.8.0",
+    "ember-data": "^2.8.1",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-metrics": "0.6.2",


### PR DESCRIPTION
There is a performance regression with the latest Ember beta that was addressed in Ember Data 2.8.1 (https://github.com/emberjs/data/pull/4545).