### PR TITLE
Fixes issue with mock api proxy url

### DIFF
--- a/server/proxies/api.js
+++ b/server/proxies/api.js
@@ -12,6 +12,6 @@ module.exports = function(app) {
   app.use(proxyPath, function(req, res, next){
     // include root path in proxied request
     req.url = proxyPath + '/' + req.url;
-    proxy.web(req, res, { target: 'http://localhost:3000' });
+    proxy.web(req, res, { target: 'https://emberobserver.com' });
   });
 };


### PR DESCRIPTION
Small change to set the mock API proxy from "localhost:3000" to "emberobserver.com" and enable a functional local dev environment for new contributors.