### PR TITLE
Adds loading templates to long-loading routes 

### DIFF
--- a/app/styles/_loading.scss
+++ b/app/styles/_loading.scss
@@ -1,0 +1,3 @@
+.loading {
+  margin-top: 30%;
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -24,6 +24,7 @@
 @import "about_index";
 @import "admin_build_result";
 @import "components/page-layout";
+@import "loading";
 
 ::-ms-clear {
   display: none;

--- a/app/templates/addons/loading.hbs
+++ b/app/templates/addons/loading.hbs
@@ -1,0 +1,3 @@
+<div class="loading">
+  {{dot-spinner}}
+</div>

--- a/app/templates/categories/loading.hbs
+++ b/app/templates/categories/loading.hbs
@@ -1,0 +1,3 @@
+<div class="loading">
+  {{dot-spinner}}
+</div>

--- a/app/templates/lists/loading.hbs
+++ b/app/templates/lists/loading.hbs
@@ -1,0 +1,3 @@
+<div class="loading">
+  {{dot-spinner}}
+</div>

--- a/app/templates/maintainers/loading.hbs
+++ b/app/templates/maintainers/loading.hbs
@@ -1,0 +1,3 @@
+<div class="loading">
+  {{dot-spinner}}
+</div>


### PR DESCRIPTION
Resolves issue #72:

* adds [ember-spin-kit](https://github.com/angelomachado/ember-spin-kit) addon (additional CSS dependency)
* adds loading templates to `addons`, `categories`, `lists` and `maintainers` routes, which seemed to be the most critical cases. it could a be general `loading` template on the `application` level, but that's more of a design/UX question, if you really want to show loading on everything.