### PR TITLE
Minor top margin fix for loading spinner

### DIFF
--- a/app/styles/_loading.scss
+++ b/app/styles/_loading.scss
@@ -1,3 +1,3 @@
 .loading {
-  margin-top: 30%;
+  margin-top: 20vh;
 }


### PR DESCRIPTION
Amends #77.

Just noticed a the `margin-top` looked a little funny when dev-tools where off and the footer had a different height. This change makes the spinner appear a little more consistent across the routes where it's applied.