### PR TITLE
code search: link to the matched source code

### DIFF
--- a/app/templates/components/addon-source-usages.hbs
+++ b/app/templates/components/addon-source-usages.hbs
@@ -7,7 +7,9 @@
     {{#if usages}}
       {{#each visibleUsages as |usage|}}
         <div class="usage test-usage">
-          <div class="filename">{{usage.filename}}:{{usage.line_number}}</div>
+          <a class="filename" href="{{addon.repositoryUrl}}/tree/master/{{usage.filename}}#L{{usage.line_number}}">
+            {{usage.filename}}:{{usage.line_number}}
+          </a>
           {{#each usage.lines as |line|}}
             <pre class="line"><span class="number">{{pad-line-number line.number usage.lines}}</span><span class="{{if (is-equal usage.line_number line.number) 'match'}}">{{line.text}}</span></pre>
           {{/each}}

--- a/tests/acceptance/code-search-test.js
+++ b/tests/acceptance/code-search-test.js
@@ -114,6 +114,11 @@ test('viewing addon source containing search query', function(assert) {
     assert.exists('.test-usage .match:contains("store: inject.service(),")', 'Second match is highlighted correctly');
 
     assert.exists('.test-usage:contains("app/components/fake-thing.js:21")', 'Shows both usages');
+
+    assert.equal(
+      find('.test-usage:contains("fake-service") a').attr('href'),
+      'https://github.com/kategengler/ember-feature-flags/tree/master/app/services/fake-service.js#L52',
+      'Link to the matched source code line');
   });
 
   click('.test-usage-count');


### PR DESCRIPTION
The code search has been incredibly useful for my work on [ember-typings](https://github.com/typed-ember/ember-typings). It's almost like having API documentation! Links would make it even better

Fixes #89