### PR TITLE
Code search result filtering take 2

### DIFF
--- a/app/components/addon-source-usages.js
+++ b/app/components/addon-source-usages.js
@@ -48,7 +48,12 @@ function filterByFilePath(usages, filterTerm) {
   if (isEmpty(filterTerm)) {
     return usages;
   }
-  let filterRegex = new RegExp(filterTerm);
+  let filterRegex;
+  try {
+    filterRegex = new RegExp(filterTerm);
+  } catch(e) {
+    return [];
+  }
   return usages.filter((usage) => {
     return usage.filename.match(filterRegex);
   });

--- a/app/components/code-search.js
+++ b/app/components/code-search.js
@@ -175,7 +175,12 @@ function filterByFilePath(results, filterTerm) {
   }
 
   let filteredList = [];
-  let filterRegex = new RegExp(filterTerm);
+  let filterRegex;
+  try {
+    filterRegex = new RegExp(filterTerm);
+  } catch(e) {
+    return [];
+  }
   results.forEach((result) => {
     let filteredFiles = result.files.filter((filePath) => {
       return filePath.match(filterRegex);

--- a/app/components/code-search.js
+++ b/app/components/code-search.js
@@ -23,11 +23,19 @@ export default Ember.Component.extend({
 
   codeSearch: inject.service(),
 
-  usageCounts: computed.mapBy('results.filteredResults', 'count'),
+  usageCounts: computed.mapBy('results.rawResults', 'count'),
+
+  filteredUsageCounts: computed.mapBy('results.filteredResults', 'count'),
 
   totalUsageCount: computed.sum('usageCounts'),
 
+  totalFilteredUsageCount: computed.sum('filteredUsageCounts'),
+
   isFilterApplied: computed.notEmpty('fileFilter'),
+
+  showFilteredUsages: computed('isFilterApplied', 'isUpdatingFilter', function() {
+    return this.get('isFilterApplied') && !this.get('isUpdatingFilter');
+  }),
 
   init() {
     this._super(...arguments);
@@ -131,6 +139,10 @@ export default Ember.Component.extend({
   focus() {
     this.$(this.get('focusNode')).focus();
   },
+
+  isUpdatingResults: computed.or('applyFileFilter.isRunning', 'clearFileFilter.isRunning', 'sortBy.isRunning'),
+
+  isUpdatingFilter: computed.or('applyFileFilter.isRunning', 'clearFileFilter.isRunning'),
 
   actions: {
     clearSearch() {

--- a/app/components/code-search.js
+++ b/app/components/code-search.js
@@ -78,7 +78,7 @@ export default Ember.Component.extend({
     });
   },
 
-  canViewMore: computed('results.displayingResults', function() {
+  canViewMore: computed('results.displayingResults.length', 'results.length', function() {
     return this.get('results.displayingResults.length') < this.get('results.length');
   }),
 

--- a/app/controllers/code-search.js
+++ b/app/controllers/code-search.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  queryParams: ['codeQuery', 'sort', 'regex'],
+  queryParams: ['codeQuery', 'sort', 'regex', 'fileFilter'],
   codeQuery: '',
   sort: 'name',
-  regex: false
+  regex: false,
+  fileFilter: null
 });

--- a/app/services/code-search.js
+++ b/app/services/code-search.js
@@ -14,7 +14,7 @@ export default Ember.Service.extend({
       }
     }).then((response) => {
       return response.results.map((item) => {
-        return { addonName: item.addon, count: item.count };
+        return { addonName: item.addon, count: item.count, files: item.files };
       });
     });
   },

--- a/app/styles/components/_code-search.scss
+++ b/app/styles/components/_code-search.scss
@@ -54,14 +54,56 @@
   .result-details {
     @include clearfix;
 
+    h4 {
+      margin: .5rem 0;
+    }
+
     h5 {
-      padding-top: 2.25rem;
-      float:left;
+      padding-top: .5rem;
       line-height: 2rem;
     }
 
+  }
+
+  .result-controls {
+    padding: 0 .25rem;
+    border: 1px solid $light-gray;
+    border-width: 0 0 1px 0;
+    margin-top: 1rem;
+    @include clearfix();
+
     .sort-controls {
       float: right;
+      margin-right: .26rem;
+      margin-bottom: 1.5rem;
+
+      .button-option {
+        margin-bottom: 0;
+      }
+    }
+
+    .filter-controls {
+      float: left;
+      margin-bottom: 1.5rem;
+
+      .filter-input {
+        position: relative;
+        width: 300px;
+
+        input {
+          border: 1px solid $base-accent-color;
+          height: 36px;
+          width: 100%;
+          padding: .5rem;
+        }
+
+        .icon-close {
+          right: .4rem;
+          color: $base-accent-color;
+          font-size: 1.25rem;
+          margin-top: -.7rem;
+        }
+      }
     }
   }
 

--- a/app/styles/components/_code-search.scss
+++ b/app/styles/components/_code-search.scss
@@ -55,11 +55,10 @@
     @include clearfix;
 
     h4 {
-      margin: .5rem 0;
+      margin: .25rem 0;
     }
 
     h5 {
-      padding-top: .5rem;
       line-height: 2rem;
     }
 
@@ -67,16 +66,16 @@
 
   .result-controls {
     padding: 0 .25rem;
-    height: 100px;
     border: 1px solid $light-gray;
     border-width: 0 0 1px 0;
     margin-top: 1rem;
+    padding-bottom: 1rem;
     @include clearfix();
 
     .sort-controls {
-      float: right;
-      margin-right: .26rem;
-      margin-bottom: 1.5rem;
+      @include span-columns(6);
+      text-align: right;
+      margin-bottom: .5rem;
 
       .button-option {
         margin-bottom: 0;
@@ -84,12 +83,17 @@
     }
 
     .filter-controls {
-      float: left;
-      margin-bottom: 1.5rem;
+      @include span-columns(6);
+      margin-bottom: .5rem;
+      height: 80px;
 
       .filter-input {
+        @include media($medium-screen) {
+          width: 300px;
+        }
+
+        width: 144px;
         position: relative;
-        width: 300px;
 
         input {
           border: 1px solid $base-accent-color;
@@ -108,7 +112,8 @@
 
       .filter-results {
         display: inline-block;
-        padding-top: 2px;
+        padding-top: 10px;
+        white-space: nowrap;
       }
     }
   }
@@ -166,5 +171,9 @@
     font-weight: 700;
     cursor: pointer;
     text-decoration: underline;
+  }
+
+  .addon-list {
+    @include clearfix;
   }
 }

--- a/app/styles/components/_code-search.scss
+++ b/app/styles/components/_code-search.scss
@@ -67,6 +67,7 @@
 
   .result-controls {
     padding: 0 .25rem;
+    height: 100px;
     border: 1px solid $light-gray;
     border-width: 0 0 1px 0;
     margin-top: 1rem;
@@ -103,6 +104,11 @@
           font-size: 1.25rem;
           margin-top: -.7rem;
         }
+      }
+
+      .filter-results {
+        display: inline-block;
+        padding-top: 2px;
       }
     }
   }

--- a/app/templates/code-search.hbs
+++ b/app/templates/code-search.hbs
@@ -1,3 +1,3 @@
 {{#page-layout showCategories=true}}
-  {{code-search codeQuery=codeQuery sort=sort regex=regex}}
+  {{code-search codeQuery=codeQuery sort=sort regex=regex fileFilter=fileFilter}}
 {{/page-layout}}

--- a/app/templates/components/code-search.hbs
+++ b/app/templates/components/code-search.hbs
@@ -31,10 +31,7 @@
   <div class="result-details">
     <h4 class="test-last-search">Results for {{quotedLastSearch}}</h4>
     <h5 class="test-result-info">
-      Found {{pluralize-this results.filteredResultLength 'addon'}} ({{pluralize-this totalUsageCount 'usage'}})
-      {{#if isFilterApplied}}
-        in files matching /{{fileFilter}}/
-      {{/if}}
+      Found {{pluralize-this results.length 'addon'}} ({{pluralize-this totalUsageCount 'usage'}})
     </h5>
   </div>
   <div class="result-controls">
@@ -45,10 +42,15 @@
                value={{fileFilter}}
                  oninput={{action (perform applyFileFilter) value="target.value"}}
                class="test-file-filter-input">
-        {{#if isFilterApplied}}
+        {{#if showFilteredUsages}}
           <button type="button" {{action (perform clearFileFilter)}} class="icon-close test-clear-file-filter"></button>
         {{/if}}
       </div>
+      {{#if showFilteredUsages}}
+        <span class="filter-results test-filtered-result-info">
+          Filtered to {{pluralize-this results.filteredResultLength 'addon'}} ({{pluralize-this totalFilteredUsageCount 'usage'}})
+        </span>
+      {{/if}}
     </div>
     <div class="sort-controls">
       Sort by:
@@ -59,22 +61,26 @@
     </div>
   </div>
   <ul class="addon-list">
-    {{#each results.displayingResults as |result|}}
-      <li data-id="{{result.addon.id}}">
-        {{addon-details addon=result.addon}}
-        {{addon-source-usages
-          addon=result.addon
-          count=result.count
-          query=codeQuery
-          regex=regex
-          fileFilter=fileFilter
-        }}
-      </li>
-    {{/each}}
-    {{#if canViewMore}}
-      <a href="#" {{action (perform viewMore)}} class="view-more test-view-more">
-        <li>See more results</li>
-      </a>
+    {{#if isUpdatingResults}}
+      {{dot-spinner}}
+    {{else}}
+      {{#each results.displayingResults as |result|}}
+        <li data-id="{{result.addon.id}}">
+          {{addon-details addon=result.addon}}
+          {{addon-source-usages
+            addon=result.addon
+            count=result.count
+            query=codeQuery
+            regex=regex
+            fileFilter=fileFilter
+          }}
+        </li>
+      {{/each}}
+      {{#if canViewMore}}
+        <a href="#" {{action (perform viewMore)}} class="view-more test-view-more">
+          <li>See more results</li>
+        </a>
+      {{/if}}
     {{/if}}
   </ul>
 {{else if search.isRunning}}

--- a/app/templates/components/code-search.hbs
+++ b/app/templates/components/code-search.hbs
@@ -31,7 +31,7 @@
   <div class="result-details">
     <h4 class="test-last-search">Results for {{quotedLastSearch}}</h4>
     <h5 class="test-result-info">
-      Showing {{results.length}} {{pluralize results.length 'addon'}} ({{totalUsageCount}} {{pluralize totalUsageCount 'usage'}})
+      Found {{pluralize-this results.length 'addon'}} ({{pluralize-this totalUsageCount 'usage'}})
     </h5>
     <div class="sort-controls">
       Sort by:

--- a/app/templates/components/code-search.hbs
+++ b/app/templates/components/code-search.hbs
@@ -31,8 +31,25 @@
   <div class="result-details">
     <h4 class="test-last-search">Results for {{quotedLastSearch}}</h4>
     <h5 class="test-result-info">
-      Found {{pluralize-this results.length 'addon'}} ({{pluralize-this totalUsageCount 'usage'}})
+      Found {{pluralize-this results.filteredResultLength 'addon'}} ({{pluralize-this totalUsageCount 'usage'}})
+      {{#if isFilterApplied}}
+        in files matching /{{fileFilter}}/
+      {{/if}}
     </h5>
+  </div>
+  <div class="result-controls">
+    <div class="filter-controls">
+      Filter by file path:
+      <div class="filter-input">
+        <input type="text"
+               value={{fileFilter}}
+                 oninput={{action (perform applyFileFilter) value="target.value"}}
+               class="test-file-filter-input">
+        {{#if isFilterApplied}}
+          <button type="button" {{action (perform clearFileFilter)}} class="icon-close test-clear-file-filter"></button>
+        {{/if}}
+      </div>
+    </div>
     <div class="sort-controls">
       Sort by:
       <div class="button-select test-sort">
@@ -45,7 +62,13 @@
     {{#each results.displayingResults as |result|}}
       <li data-id="{{result.addon.id}}">
         {{addon-details addon=result.addon}}
-        {{addon-source-usages addon=result.addon count=result.count query=codeQuery regex=regex}}
+        {{addon-source-usages
+          addon=result.addon
+          count=result.count
+          query=codeQuery
+          regex=regex
+          fileFilter=fileFilter
+        }}
       </li>
     {{/each}}
     {{#if canViewMore}}

--- a/app/templates/components/code-search.hbs
+++ b/app/templates/components/code-search.hbs
@@ -49,7 +49,7 @@
       </li>
     {{/each}}
     {{#if canViewMore}}
-      <a href="#" {{action (perform viewMore)}} class="view-more">
+      <a href="#" {{action (perform viewMore)}} class="view-more test-view-more">
         <li>See more results</li>
       </a>
     {{/if}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,6 +10,7 @@ module.exports = function(environment) {
     rootURL: '/',
     locationType: 'router-scroll',
     historySupportMiddleware: true,
+    codeSearchPageSize: 50,
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
@@ -60,6 +61,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+    ENV.codeSearchPageSize = 3;
   }
 
   if (environment === 'production') {

--- a/tests/acceptance/code-search-test.js
+++ b/tests/acceptance/code-search-test.js
@@ -273,3 +273,38 @@ test('searching when sort is set in query param', function(assert) {
     assert.contains('.test-addon-name:eq(2)', 'ember-try', 'Addons are sorted by usages');
   });
 });
+
+test('viewing more results', function(assert) {
+  let addons = server.createList('addon', 51);
+
+  server.get('/search/addons', () => {
+    return {
+      results: searchResults(addons)
+    };
+  });
+
+  visit('/code-search');
+  fillIn('#code-search-input', 'TestEm.afterTests');
+  click('.test-submit-search');
+
+  andThen(function() {
+    assert.equal(50, find('.test-addon-name').length, 'First 50 results show');
+    assert.equal(1, find('.test-view-more').length, 'View more link shows');
+  });
+
+  click('.test-view-more');
+
+  andThen(function() {
+    assert.equal(51, find('.test-addon-name').length, 'All 51 results show');
+    assert.equal(0, find('.test-view-more').length, 'View more link does not show');
+  });
+});
+
+function searchResults(addons) {
+  return addons.map((addon) => {
+    return {
+      addon: addon.name,
+      count: 1
+    };
+  });
+}

--- a/tests/acceptance/code-search-test.js
+++ b/tests/acceptance/code-search-test.js
@@ -341,8 +341,10 @@ test('filtering search results by file path', function(assert) {
 
   andThen(function() {
     assert.equal(find('.test-addon-name').length, 2, 'shows only matching addons after filtering');
-    assert.contains('.test-result-info', '2 addons', 'filtered result count shows when filter is applied');
-    assert.contains('.test-result-info', '3 usages', 'filtered usage count shows when filter is applied');
+    assert.contains('.test-result-info', '3 addons', 'full result count shows when filter is applied');
+    assert.contains('.test-result-info', '6 usages', 'full usage count shows when filter is applied');
+    assert.contains('.test-filtered-result-info', '2 addons', 'filtered result count shows when filter is applied');
+    assert.contains('.test-filtered-result-info', '3 usages', 'filtered usage count shows when filter is applied');
   });
 
   click('.test-clear-file-filter');
@@ -356,8 +358,8 @@ test('filtering search results by file path', function(assert) {
 
   andThen(function() {
     assert.equal(find('.test-addon-name').length, 1, 'shows only matching addons after filtering');
-    assert.contains('.test-result-info', '1 addon', 'filtered result count is correct after regex search');
-    assert.contains('.test-result-info', '1 usage', 'filtered usage count is correct after regex search');
+    assert.contains('.test-filtered-result-info', '1 addon', 'filtered result count is correct after regex search');
+    assert.contains('.test-filtered-result-info', '1 usage', 'filtered usage count is correct after regex search');
   });
 });
 
@@ -496,8 +498,8 @@ test('filtering works with sorting and pagination', function(assert) {
 
   andThen(function() {
     assert.equal(find('.test-addon-name').length, 3, 'shows one page worth of addons after filtering');
-    assert.contains('.test-result-info', '4 addons', 'filtered addon count shows when filter is applied');
-    assert.contains('.test-result-info', '6 usages', 'filtered usage count shows when filter is applied');
+    assert.contains('.test-filtered-result-info', '4 addons', 'filtered addon count shows when filter is applied');
+    assert.contains('.test-filtered-result-info', '6 usages', 'filtered usage count shows when filter is applied');
     assert.contains('.test-addon-name:eq(0)', 'ember-cli-thing', 'addons are sorted by usage count');
   });
 
@@ -511,8 +513,8 @@ test('filtering works with sorting and pagination', function(assert) {
 
   andThen(function() {
     assert.equal(find('.test-addon-name').length, 3, 'resets to first page after sorting');
-    assert.contains('.test-result-info', '4 addons', 'filtered addon count still shows after sorting');
-    assert.contains('.test-result-info', '6 usages', 'filtered usage count still shows after sorting');
+    assert.contains('.test-filtered-result-info', '4 addons', 'filtered addon count still shows after sorting');
+    assert.contains('.test-filtered-result-info', '6 usages', 'filtered usage count still shows after sorting');
     assert.contains('.test-addon-name:eq(0)', 'ember-cli-matches', 'addons are sorted by name');
   });
 
@@ -521,8 +523,8 @@ test('filtering works with sorting and pagination', function(assert) {
 
   andThen(function() {
     assert.equal(find('.test-addon-name').length, 3, 'shows first page of addons after clearing filter');
-    assert.contains('.test-result-info', '6 addons', 'un-filtered addon count shows');
-    assert.contains('.test-result-info', '17 usages', 'un-filtered usage count shows');
+    assert.notExists('.test-filtered-result-info', 'filtered result counts are gone after clearing');
+    assert.exists('.test-result-info', 'total result counts are still showing');
     assert.contains('.test-addon-name:eq(0)', 'ember-blanket', 'addons are sorted by name');
   });
 });

--- a/tests/acceptance/code-search-test.js
+++ b/tests/acceptance/code-search-test.js
@@ -238,3 +238,38 @@ test('searching with a regex', function(assert) {
     assert.equal('false', usageRegexParam, 'Regex param is included in usage request and is false');
   });
 });
+
+test('searching when sort is set in query param', function(assert) {
+  server.create('addon', { name: 'ember-try' });
+  server.create('addon', { name: 'ember-blanket' });
+  server.create('addon', { name: 'ember-foo' });
+
+  server.get('/search/addons', () => {
+    return {
+      results: [
+        {
+          addon: 'ember-try',
+          count: 1
+        },
+        {
+          addon: 'ember-blanket',
+          count: 2
+        },
+        {
+          addon: 'ember-foo',
+          count: 3
+        }
+      ]
+    };
+  });
+
+  visit('/code-search?sort=usages');
+  fillIn('#code-search-input', 'foo');
+  click('.test-submit-search');
+
+  andThen(function() {
+    assert.contains('.test-addon-name:eq(0)', 'ember-foo', 'Addons are sorted by usages');
+    assert.contains('.test-addon-name:eq(1)', 'ember-blanket', 'Addons are sorted by usages');
+    assert.contains('.test-addon-name:eq(2)', 'ember-try', 'Addons are sorted by usages');
+  });
+});


### PR DESCRIPTION
- Add ability to filter code search results down to addons with at least one file matching the given regex (requires corresponding API change)

- Filter usages down to those with file path matching the filter regex

- Show spinner in results area while sorting or changing filter to avoid awkward jumping

- Add file path filter input to UI and restyle

- Fixes a bug where 'See more results' remained visible on last page of results