### PR TITLE
Replaced direct Github API access

### DIFF
--- a/app/models/ember-versions.js
+++ b/app/models/ember-versions.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  githubResponse: DS.attr()
+});

--- a/app/serializers/ember-versions.js
+++ b/app/serializers/ember-versions.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  modelNameFromPayloadKey(key) {
+    return key;
+  }
+});

--- a/app/services/ember-versions.js
+++ b/app/services/ember-versions.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 
 export default Ember.Service.extend({
   ajax: Ember.inject.service(),
+  features: Ember.inject.service(),
+  store: Ember.inject.service(),
   data: null,
   url: 'https://api.github.com/repos/emberjs/ember.js/releases?per_page=100',
   isLoaded: Ember.computed.notEmpty('data'),
@@ -16,11 +18,20 @@ export default Ember.Service.extend({
     if (this.get('isLoaded')) {
       return;
     }
-    this.get('ajax').request(this.url).then((response) => {
-      this.set('data', response);
-    }).catch(() => {
-      this.set('data', null);
-    });
+
+    if (this.get('features').isEnabled('ember-versions-model')) {
+      this.get('store').queryRecord('ember-versions', {}).then((response) => {
+        this.set('data', response.get('githubResponse'));
+      }).catch(() => {
+        this.set('data', null);
+      });
+    } else {
+      this.get('ajax').request(this.url).then((response) => {
+        this.set('data', response);
+      }).catch(() => {
+        this.set('data', null);
+      });
+    }
   }
 });
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -66,6 +66,7 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
+    ENV.featureFlags['ember-versions-model'] = false;
   }
 
   return ENV;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -148,6 +148,10 @@ export default function() {
     };
   });
 
+  this.get('/ember-versions', function(schema) {
+    return schema.emberVersions.first();
+  });
+
   this.get('https://api.github.com/repos/emberjs/ember.js/releases', function(/* db, request*/) {
     return EmberVersionsResponse;
   });

--- a/mirage/models/ember-versions.js
+++ b/mirage/models/ember-versions.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-concurrency": "^0.8.12",
     "ember-data": "~2.13.0",
     "ember-export-application-global": "^2.0.0",
+    "ember-feature-flags": "^4.1.0",
     "ember-load-initializers": "^1.0.0",
     "ember-metrics": "^0.12.1",
     "ember-moment": "^7.5.0",

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
   globals: {
     server: true,
     visitAddon: true,
-    selectChoose: true
+    selectChoose: true,
+    withFeature: false
   }
 };

--- a/tests/unit/services/ember-versions-test.js
+++ b/tests/unit/services/ember-versions-test.js
@@ -3,7 +3,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('service:ember-versions', 'Unit | Service | ember versions', {
   // Specify the other units that are required for this test.
-  needs: ['service:ajax']
+  needs: ['service:ajax', 'service:features']
 });
 
 test('versionData returns empty array if data is empty', function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,6 +2823,12 @@ ember-factory-for-polyfill@^1.1.0:
   dependencies:
     ember-cli-version-checker "^1.2.0"
 
+ember-feature-flags@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ember-feature-flags/-/ember-feature-flags-4.1.0.tgz#e3ab80a02ccef1877f568996afc3191dc3690d10"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+
 ember-getowner-polyfill@^1.1.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.5.tgz#ceff8a09897d0d7e05c821bb71666a95eb26dc92"


### PR DESCRIPTION
- Added `emberVersions` model
- New model has a "githubResponse" attribute, I learned that "data" is a protected name for DS.Model attributes.
- `JSONAPISerializer` was resolving payload oddly because of pluralized model name, so I added a ember-versions serializer as a workaround.
- Installed ember-feature-flags