### PR TITLE
Added new sorting to code search results

### DIFF
--- a/app/components/code-search.js
+++ b/app/components/code-search.js
@@ -110,18 +110,23 @@ export default Component.extend({
       return resolve(null);
     }
 
-    let sortedResults = sortResults(results, sort);
-    let pageOfResults = sortedResults.slice((page - 1) * PageSize, page * PageSize);
-    let names = pageOfResults.mapBy('addonName');
-    return this.get('store').query('addon', { filter: { name: names.join(',') }, include: 'categories' }).then((addons) => {
-      return pageOfResults.map((result) => {
+    let names = results.mapBy('addonName');
+
+    return this.get('store').query('addon', {
+      filter: { name: names.join(',') },
+      include: 'categories'
+    }).then((addons) => {
+      let mappedResults = results.map((result) => {
         return {
           addon: addons.findBy('name', result.addonName),
           count: result.count,
-          score: result.score,
           files: result.files
         };
       });
+
+      let sortedResults = sortResults(mappedResults, sort);
+      let pageOfResults = sortedResults.slice((page - 1) * PageSize, page * PageSize);
+      return pageOfResults;
     });
   },
 
@@ -163,7 +168,7 @@ export default Component.extend({
 
 function sortResults(results, sort) {
   if (sort === 'score') {
-    return results.sortBy('score').reverse();
+    return results.sortBy('addon.score').reverse();
   }
 
   if (sort === 'usages') {
@@ -171,7 +176,7 @@ function sortResults(results, sort) {
   }
 
   if (sort === 'name') {
-    return results.sortBy('addonName');
+    return results.sortBy('addon.name');
   }
 }
 

--- a/app/components/code-search.js
+++ b/app/components/code-search.js
@@ -15,6 +15,8 @@ export default Component.extend({
 
   store: service(),
 
+  features: service(),
+
   codeQuery: null,
 
   sort: null,
@@ -116,6 +118,7 @@ export default Component.extend({
         return {
           addon: addons.findBy('name', result.addonName),
           count: result.count,
+          score: result.score,
           files: result.files
         };
       });
@@ -159,6 +162,10 @@ export default Component.extend({
 });
 
 function sortResults(results, sort) {
+  if (sort === 'score') {
+    return results.sortBy('score').reverse();
+  }
+
   if (sort === 'usages') {
     return results.sortBy('count').reverse();
   }

--- a/app/components/code-search.js
+++ b/app/components/code-search.js
@@ -171,6 +171,10 @@ function sortResults(results, sort) {
     return results.sortBy('addon.score').reverse();
   }
 
+  if (sort === 'updated') {
+    return results.sortBy('addon.latestVersionDate').reverse();
+  }
+
   if (sort === 'usages') {
     return results.sortBy('count').reverse();
   }

--- a/app/services/code-search.js
+++ b/app/services/code-search.js
@@ -12,7 +12,7 @@ export default Service.extend({
       }
     }).then((response) => {
       return response.results.map((item) => {
-        return { addonName: item.addon, count: item.count, files: item.files, score: item.score };
+        return { addonName: item.addon, count: item.count, files: item.files };
       });
     });
   },

--- a/app/services/code-search.js
+++ b/app/services/code-search.js
@@ -12,7 +12,7 @@ export default Service.extend({
       }
     }).then((response) => {
       return response.results.map((item) => {
-        return { addonName: item.addon, count: item.count, files: item.files };
+        return { addonName: item.addon, count: item.count, files: item.files, score: item.score };
       });
     });
   },

--- a/app/templates/components/code-search.hbs
+++ b/app/templates/components/code-search.hbs
@@ -57,8 +57,9 @@
       <div class="button-select test-sort">
         {{sort-option name="Name" key="name" selectedSort=sort sortBy=(perform sortBy)}}
         {{sort-option name="Usages" key="usages" selectedSort=sort sortBy=(perform sortBy)}}
-        {{#if features.codeSearchScoreSorting}}
+        {{#if features.newCodeSearchSorting}}
           {{sort-option name="Score" key="score" selectedSort=sort sortBy=(perform sortBy)}}
+          {{sort-option name="Updated" key="updated" selectedSort=sort sortBy=(perform sortBy)}}
         {{/if}}
       </div>
     </div>

--- a/app/templates/components/code-search.hbs
+++ b/app/templates/components/code-search.hbs
@@ -57,6 +57,9 @@
       <div class="button-select test-sort">
         {{sort-option name="Name" key="name" selectedSort=sort sortBy=(perform sortBy)}}
         {{sort-option name="Usages" key="usages" selectedSort=sort sortBy=(perform sortBy)}}
+        {{#if features.codeSearchScoreSorting}}
+          {{sort-option name="Score" key="score" selectedSort=sort sortBy=(perform sortBy)}}
+        {{/if}}
       </div>
     </div>
   </div>

--- a/tests/acceptance/code-search-test.js
+++ b/tests/acceptance/code-search-test.js
@@ -1,4 +1,4 @@
-import { pauseTest, click, fillIn, findAll, currentURL, visit } from '@ember/test-helpers';
+import { click, fillIn, findAll, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
 import { enableFeature } from 'ember-feature-flags/test-support';
@@ -126,10 +126,23 @@ module('Acceptance | code search', function(hooks) {
   });
 
   test('sorting search results', async function(assert) {
-    enableFeature(this.owner, 'code-search-score-sorting');
-    server.create('addon', { name: 'ember-try', score: 3 });
-    server.create('addon', { name: 'ember-blanket', score: 2 });
-    server.create('addon', { name: 'ember-foo', score: 1 });
+    enableFeature(this.owner, 'new-code-search-sorting');
+
+    server.create('addon', {
+      name: 'ember-try',
+      score: 3,
+      latestVersionDate: window.moment().subtract(2, 'days')
+    });
+    server.create('addon', {
+      name: 'ember-blanket',
+      score: 2,
+      latestVersionDate: window.moment().subtract(3, 'days')
+    });
+    server.create('addon', {
+      name: 'ember-foo',
+      score: 1,
+      latestVersionDate: window.moment().subtract(1, 'days')
+    });
 
     server.get('/search/addons', () => {
       return {
@@ -170,10 +183,18 @@ module('Acceptance | code search', function(hooks) {
     await click(findByText('.test-sort button','Score'));
 
     let scoreSortedAddonNames = findAll('.test-addon-name');
-    assert.dom(scoreSortedAddonNames[0]).containsText('ember-try', 'Addons are sorted by score count');
-    assert.dom(scoreSortedAddonNames[1]).containsText('ember-blanket', 'Addons are sorted by score count');
-    assert.dom(scoreSortedAddonNames[2]).containsText('ember-foo', 'Addons are sorted by score count');
+    assert.dom(scoreSortedAddonNames[0]).containsText('ember-try', 'Addons are sorted by score');
+    assert.dom(scoreSortedAddonNames[1]).containsText('ember-blanket', 'Addons are sorted by score');
+    assert.dom(scoreSortedAddonNames[2]).containsText('ember-foo', 'Addons are sorted by score');
     assert.equal(currentURL(), '/code-search?codeQuery=foo&sort=score', 'Sort is in query params');
+
+    await click(findByText('.test-sort button','Updated'));
+
+    let latestVersionDateSortedNames = findAll('.test-addon-name');
+    assert.dom(latestVersionDateSortedNames[0]).containsText('ember-foo', 'Addons are sorted by latest version date');
+    assert.dom(latestVersionDateSortedNames[1]).containsText('ember-try', 'Addons are sorted by latest version date');
+    assert.dom(latestVersionDateSortedNames[2]).containsText('ember-blanket', 'Addons are sorted by latest version date');
+    assert.equal(currentURL(), '/code-search?codeQuery=foo&sort=updated', 'Sort is in query params');
   });
 
   test('searching with a regex', async function(assert) {

--- a/tests/acceptance/code-search-test.js
+++ b/tests/acceptance/code-search-test.js
@@ -127,27 +127,24 @@ module('Acceptance | code search', function(hooks) {
 
   test('sorting search results', async function(assert) {
     enableFeature(this.owner, 'code-search-score-sorting');
-    server.create('addon', { name: 'ember-try' });
-    server.create('addon', { name: 'ember-blanket' });
-    server.create('addon', { name: 'ember-foo' });
+    server.create('addon', { name: 'ember-try', score: 3 });
+    server.create('addon', { name: 'ember-blanket', score: 2 });
+    server.create('addon', { name: 'ember-foo', score: 1 });
 
     server.get('/search/addons', () => {
       return {
         results: [
           {
             addon: 'ember-try',
-            count: 1,
-            score: 3
+            count: 1
           },
           {
             addon: 'ember-blanket',
-            count: 2,
-            score: 2
+            count: 2
           },
           {
             addon: 'ember-foo',
-            count: 3,
-            score: 1
+            count: 3
           }
         ]
       };


### PR DESCRIPTION
This PR addresses half of the #99 feature request.

- Sorting button behind `code-search-score-sorting` feature flag
- `/search/addons` endpoint will need to include `score` in results (doesn't currently appear to)
