### PR TITLE
Improve handling of scoped packages in URLs

### DIFF
--- a/app/models/addon.js
+++ b/app/models/addon.js
@@ -39,9 +39,6 @@ export default Model.extend({
   npmUrl: computed('name', function() {
     return `https://www.npmjs.com/package/${this.get('name')}`;
   }),
-  escapedName: computed('name', function() {
-    return this.get('name').replace('/', '%2F');
-  }),
   isNewAddon: computed('publishedDate', function() {
     return moment(this.get('publishedDate')).isAfter(moment().subtract(2, 'weeks'));
   })

--- a/app/router.js
+++ b/app/router.js
@@ -48,8 +48,8 @@ Router.map(function() {
   });
 
   this.route('addons', function() {
-    this.route('show', { path: '/:name' });
-    this.route('correct', { path: '/:name/correct' });
+    this.route('correct', { path: '/*name/correct' });
+    this.route('show', { path: '/*name' });
     this.route('top', { path: '/lists/top' });
   });
 

--- a/app/routes/addons/correct.js
+++ b/app/routes/addons/correct.js
@@ -2,7 +2,8 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   model(params) {
-    return this.get('store').query('addon', { filter: { name: params.name }, page: { limit: 1 } }, { reload: true }).then((addons) => {
+    let name = params.name.replace(/%2F/i, '/');
+    return this.get('store').query('addon', { filter: { name }, page: { limit: 1 } }, { reload: true }).then((addons) => {
       return addons.get('firstObject');
     });
   }

--- a/app/routes/addons/show.js
+++ b/app/routes/addons/show.js
@@ -5,11 +5,12 @@ import Route from '@ember/routing/route';
 export default Route.extend({
   session: service(),
   model(params) {
-    let addon = this.get('store').query('addon', { filter: { name: params.name }, include: 'versions,maintainers,keywords,reviews,reviews.version,categories', page: { limit: 1 } }, { reload: true }).then((addons) => {
+    let name = params.name.replace(/%2F/i, '/');
+    let addon = this.get('store').query('addon', { filter: { name }, include: 'versions,maintainers,keywords,reviews,reviews.version,categories', page: { limit: 1 } }, { reload: true }).then((addons) => {
       return addons.get('firstObject');
     });
 
-    let latestTestResult = this.get('store').query('test-result', { filter: { canary: false, addonName: params.name }, sort: '-createdAt', page: { limit: 1 }, include: 'ember-version-compatibilities' }).then((results) => {
+    let latestTestResult = this.get('store').query('test-result', { filter: { canary: false, addonName: name }, sort: '-createdAt', page: { limit: 1 }, include: 'ember-version-compatibilities' }).then((results) => {
       return results.get('firstObject');
     });
 

--- a/app/templates/components/stats-bar.hbs
+++ b/app/templates/components/stats-bar.hbs
@@ -86,7 +86,7 @@
   {{#if showBadgeText}}
     <hr>
     <code class="test-badge-markdown">
-      [![Ember Observer Score](https://emberobserver.com{{badge-path addon.name}})](https://emberobserver.com/addons/{{addon.escapedName}})
+      [![Ember Observer Score](https://emberobserver.com{{badge-path addon.name}})](https://emberobserver.com/addons/{{addon.name}})
     </code>
   {{/if}}
 </section>

--- a/tests/acceptance/addons-test.js
+++ b/tests/acceptance/addons-test.js
@@ -417,7 +417,7 @@ module('Acceptance: Addons', function(hooks) {
       assert.dom('.test-addon-badge img[src="/badges/-foo-bar-test-addon.svg"]').exists();
 
       await click('.test-addon-badge .test-show-badge-markdown');
-      assert.dom('.test-addon-badge .test-badge-markdown').hasText('[![Ember Observer Score](https://emberobserver.com/badges/-foo-bar-test-addon.svg)](https://emberobserver.com/addons/@foo-bar%2Ftest-addon)');
+      assert.dom('.test-addon-badge .test-badge-markdown').hasText('[![Ember Observer Score](https://emberobserver.com/badges/-foo-bar-test-addon.svg)](https://emberobserver.com/addons/@foo-bar/test-addon)');
     });
 
   });

--- a/tests/helpers/visit-addon.js
+++ b/tests/helpers/visit-addon.js
@@ -1,5 +1,5 @@
 import { visit } from '@ember/test-helpers';
 
 export default async function visitAddon(addon) {
-  return visit(`/addons/${addon.name.replace('/', '%2F')}`);
+  return visit(`/addons/${addon.name}`);
 }


### PR DESCRIPTION
Use wildcard params in the router to allow addons with slashes in their names (i.e., scoped addons) to be reached without having to escape the slash character.