### PR TITLE
Remove trailing '.git' from repo URLs in code search

### DIFF
--- a/app/helpers/clean-repo-url.js
+++ b/app/helpers/clean-repo-url.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function cleanRepoUrl([repoUrl]) {
+  return (repoUrl || '').replace(/\.git$/, '');
+}
+
+export default helper(cleanRepoUrl);

--- a/app/templates/components/addon-source-usages.hbs
+++ b/app/templates/components/addon-source-usages.hbs
@@ -7,7 +7,7 @@
     {{#if usages}}
       {{#each visibleUsages as |usage|}}
         <div class="usage test-usage">
-          <a class="filename" href="{{addon.repositoryUrl}}/tree/master/{{usage.filename}}#L{{usage.line_number}}">
+          <a class="filename" href="{{clean-repo-url addon.repositoryUrl}}/tree/master/{{usage.filename}}#L{{usage.line_number}}">
             {{usage.filename}}:{{usage.line_number}}
           </a>
           {{#each usage.lines as |line|}}

--- a/tests/integration/helpers/clean-repo-url-test.js
+++ b/tests/integration/helpers/clean-repo-url-test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | clean-repo-url', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it removes trailing .git from repo URLs', async function(assert) {
+    this.set('repoUrl', 'http://example.com/someone/something.git');
+
+    await render(hbs`{{clean-repo-url repoUrl}}`);
+
+    assert.equal(this.element.textContent.trim(), 'http://example.com/someone/something');
+  });
+
+  test('it does not remove non-trailing ".git"', async function(assert) {
+    let repoUrl = 'http://example.com/someone.git/something';
+    this.set('repoUrl', repoUrl);
+
+    await render(hbs`{{clean-repo-url repoUrl}}`);
+
+    assert.equal(this.element.textContent.trim(), repoUrl);
+  });
+
+  test('it does nothing to URLs that lack .git', async function(assert) {
+    let repoUrl = 'http://example.com/someone/something';
+    this.set('repoUrl', repoUrl);
+
+    await render(hbs`{{clean-repo-url repoUrl}}`);
+
+    assert.equal(this.element.textContent.trim(), repoUrl);
+  });
+});


### PR DESCRIPTION
Fixes #114 