### PR TITLE
Removed neat usage from login

### DIFF
--- a/app/styles/_login.scss
+++ b/app/styles/_login.scss
@@ -2,7 +2,7 @@
   margin-top: 1em;
 
   form {
-    @include span-columns(3);
+    float: left;
   }
 
   input[type=submit] {


### PR DESCRIPTION
#118 

First of a few PR's to remove [Neat](https://neat.bourbon.io/) in favour of flexbox.

## Screenshots

### Before
Mobile:
<img width="403" alt="image" src="https://user-images.githubusercontent.com/7291324/42827805-44991eee-89b5-11e8-8ed5-67735941b07e.png">

Desktop:
<img width="2553" alt="image" src="https://user-images.githubusercontent.com/7291324/42827771-36f6f824-89b5-11e8-9ee5-d64dacbf56e9.png">


### After
Mobile: 
<img width="421" alt="image" src="https://user-images.githubusercontent.com/7291324/42827711-0f67ae3e-89b5-11e8-9eac-c3924bec6c53.png">

Desktop:
<img width="1314" alt="image" src="https://user-images.githubusercontent.com/7291324/42827726-1be9095a-89b5-11e8-8310-002397872495.png">
