### PR TITLE
Removed neat grid usage from addon readme's

### DIFF
--- a/app/styles/_addons_show.scss
+++ b/app/styles/_addons_show.scss
@@ -255,7 +255,6 @@
   }
 
   .readme {
-    @include span-columns(12);
     @include readme-styles();
   }
 }


### PR DESCRIPTION
Part of #118 

The readme class is on a `<section>` element so it assumes its parent's width without needing to apply `@include span-columns(12)`.