### PR TITLE
Resolve bower deprecation issue

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,5 @@
 {
   "directory": "bower_components",
-  "analytics": false
+  "analytics": false,
+  "registry": "https://registry.bower.io"
 }


### PR DESCRIPTION
Because bower and the bower registry have been deprecated, manually specifying the registry location is required to avoid 502 errors during install.