### PR TITLE
Preserve scroll position for code-search

### DIFF
--- a/app/controllers/code-search.js
+++ b/app/controllers/code-search.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   queryParams: ['codeQuery', 'sort', 'sortAscending', 'regex', 'fileFilter'],
+  preserveScrollPosition: true,
   codeQuery: '',
   sort: 'name',
   sortAscending: true,

--- a/tests/acceptance/code-search-test.js
+++ b/tests/acceptance/code-search-test.js
@@ -175,7 +175,10 @@ module('Acceptance | code search', function(hooks) {
     assert.dom(nameSortButton).hasClass('selected');
     assert.ok(nameSortButton.querySelector('.icon-expand-less'));
 
+    window.scrollTo(0, 10);
     await click(usageSortButton);
+
+    assert.notEqual(window.pageYOffset, 0, 'Page remains scrolled (not at top)');
 
     let resortedAddonNames = findAll('.test-addon-name');
     assert.dom(resortedAddonNames[0]).containsText('ember-foo', 'Addons are sorted descending by default for switch to usage count sort');
@@ -380,7 +383,10 @@ module('Acceptance | code search', function(hooks) {
 
     assert.dom('.test-addon-name').exists({ count: 3 }, 'shows all addons before filtering');
 
+    window.scrollTo(0, 10);
     await fillIn('.test-file-filter-input', filterTerm);
+
+    assert.notEqual(window.pageYOffset, 0, 'Page remains scrolled (not at top)');
 
     assert.dom('.test-addon-name').exists({ count: 2 }, 'shows only matching addons after filtering');
     assert.dom('.test-result-info').containsText('3 addons', 'full result count shows when filter is applied');


### PR DESCRIPTION
Resolves #103 

Retains scroll position when filtering and sorting for code-search.

_Open to the suggestion of writing a test that exclusively tests scroll position, but there's a lot of boiler plate code to test them so I opted for pushing two small asserts into existing tests._