### PR TITLE
Added percy integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ember-metrics": "^0.13.0",
     "ember-moment": "^7.6.0",
     "ember-pad": "1.2.3",
+    "ember-percy": "^1.5.0",
     "ember-power-select": "^2.2.1",
     "ember-power-select-typeahead": "^0.7.3",
     "ember-qunit": "^3.4.1",

--- a/tests/acceptance/addons-test.js
+++ b/tests/acceptance/addons-test.js
@@ -114,6 +114,8 @@ module('Acceptance: Addons', function(hooks) {
 
     await click('.info-action');
 
+    await percySnapshot('/addons/show | with github data');
+
     assert.dom('.test-github-data').containsText('TOP 10% STARRED');
     assert.dom('.test-open-issues').containsText('13');
     assert.dom('.test-open-issues').containsText('Open Issues');
@@ -201,6 +203,8 @@ module('Acceptance: Addons', function(hooks) {
     await visitAddon(addonWithReview);
 
     await click('.info-action');
+
+    await percySnapshot('/addons/show | with review');
 
     let questions = findAll('.test-review-question');
     assert.dom(questions[0]).hasText('Are there meaningful tests? Yes');
@@ -404,13 +408,12 @@ module('Acceptance: Addons', function(hooks) {
     test('can view a scoped addon with a / in the URL', async function(assert) {
       await visit('/addons/@foo-bar/test-addon');
 
-      await percySnapshot('/addons/show');
-
       assert.equal(currentRouteName(), 'addons.show');
     });
 
     test('can view a scoped addon with / encoded in the URL', async function(assert) {
       await visit('/addons/@foo-bar%2Ftest-addon');
+
       assert.equal(currentRouteName(), 'addons.show');
     });
 

--- a/tests/acceptance/addons-test.js
+++ b/tests/acceptance/addons-test.js
@@ -1,15 +1,17 @@
 import { click, currentRouteName, currentURL, visit, findAll } from '@ember/test-helpers';
-import { module, test } from 'qunit';
-import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
-import visitAddon from '../helpers/visit-addon';
 import { enableFeature } from 'ember-feature-flags/test-support';
+import { module, test } from 'qunit';
+import { percySnapshot } from 'ember-percy';
+import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
 import moment from 'moment';
+import visitAddon from '../helpers/visit-addon';
 
 module('Acceptance: Addons', function(hooks) {
   setupEmberObserverTest(hooks);
 
   test('addon not found', async function(assert) {
     await visit('/addons/what');
+    await percySnapshot('addon not found');
     assert.equal(currentURL(), '/model-not-found');
     assert.dom('.test-not-found').hasText("Oops! We can't find what you were looking for. Try searching above?");
   });

--- a/tests/acceptance/addons-test.js
+++ b/tests/acceptance/addons-test.js
@@ -11,7 +11,9 @@ module('Acceptance: Addons', function(hooks) {
 
   test('addon not found', async function(assert) {
     await visit('/addons/what');
-    await percySnapshot('addon not found');
+
+    await percySnapshot('/model-not-found');
+
     assert.equal(currentURL(), '/model-not-found');
     assert.dom('.test-not-found').hasText("Oops! We can't find what you were looking for. Try searching above?");
   });
@@ -401,6 +403,9 @@ module('Acceptance: Addons', function(hooks) {
 
     test('can view a scoped addon with a / in the URL', async function(assert) {
       await visit('/addons/@foo-bar/test-addon');
+
+      await percySnapshot('/addons/show');
+
       assert.equal(currentRouteName(), 'addons.show');
     });
 

--- a/tests/acceptance/addons-test.js
+++ b/tests/acceptance/addons-test.js
@@ -411,7 +411,6 @@ module('Acceptance: Addons', function(hooks) {
     assert.equal(currentURL(), '/addons/test-addon/correct', 'suggest a correction link works');
   });
 
-
   module('Scoped addons', function(hooks) {
     hooks.beforeEach(function() {
       this.addon = server.create('addon', {

--- a/tests/acceptance/addons-test.js
+++ b/tests/acceptance/addons-test.js
@@ -296,7 +296,6 @@ module('Acceptance: Addons', function(hooks) {
 
     assert.dom('.test-addon-badge img[src="/badges/test-addon.svg"]').exists();
     assert.dom('.test-addon-badge .test-show-badge-markdown .icon-content-paste').exists('Show badge markdown to copy');
-    assert.dom('.test-addon-correction-link[href*="/addons/test-addon/correct"]').exists('Suggest a correction');
 
     await click('.test-addon-badge .test-show-badge-markdown');
     assert.dom('.test-addon-badge .test-badge-markdown').hasText('[![Ember Observer Score](https://emberobserver.com/badges/test-addon.svg)](https://emberobserver.com/addons/test-addon)');
@@ -397,6 +396,21 @@ module('Acceptance: Addons', function(hooks) {
     assert.dom('.test-dependencies').doesNotExist();
     assert.dom('.test-dev-dependencies').doesNotExist();
   });
+
+  test('has a link for users to provide suggestions', async function(assert) {
+    let addon = server.create('addon', {
+      name: 'test-addon',
+    });
+
+    await visitAddon(addon);
+
+    await click('.test-addon-correction-link');
+
+    await percySnapshot('/addons/correct');
+
+    assert.equal(currentURL(), '/addons/test-addon/correct', 'suggest a correction link works');
+  });
+
 
   module('Scoped addons', function(hooks) {
     hooks.beforeEach(function() {

--- a/tests/acceptance/admin-review-addon-test.js
+++ b/tests/acceptance/admin-review-addon-test.js
@@ -88,6 +88,8 @@ module('Acceptance | admin review addon', function(hooks) {
 
     await visitAddon(addon);
 
+    await percySnapshot('/admin/review/addon');
+
     assert.dom('.test-addon-link').includesText('fake-addon');
     assert.dom('.test-description').includesText('Foo bar baz');
     assert.dom('.test-last-updated').hasText('1.1.3 from a day ago');

--- a/tests/acceptance/admin-review-addon-test.js
+++ b/tests/acceptance/admin-review-addon-test.js
@@ -1,17 +1,18 @@
-import { module, test } from 'qunit';
 import {
-  visit,
-  currentURL,
   click,
+  currentURL,
   fillIn,
   findAll,
+  visit,
 } from '@ember/test-helpers';
-import Mirage from 'ember-cli-mirage';
+import { module, test } from 'qunit';
+import { percySnapshot } from 'ember-percy';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
-import moment from 'moment';
 import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
-import login from 'ember-observer/tests/helpers/login';
 import findByText from '../helpers/find-by-text';
+import login from 'ember-observer/tests/helpers/login';
+import Mirage from 'ember-cli-mirage';
+import moment from 'moment';
 
 let windowAlert;
 

--- a/tests/acceptance/admin-test.js
+++ b/tests/acceptance/admin-test.js
@@ -1,5 +1,6 @@
 import { click, fillIn, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
+import { percySnapshot } from 'ember-percy';
 import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
 
 module('Acceptance: admin', function(hooks) {
@@ -24,10 +25,16 @@ module('Acceptance: admin', function(hooks) {
     });
 
     await visit('/login');
+
+    await percySnapshot('/login');
+
     await fillIn('.test-email', 'test@example.com');
     await fillIn('.test-password', 'password123');
     await click('.test-log-in');
     await visit('/admin');
+
+    await percySnapshot('/admin/index');
+
     assert.equal(currentURL(), '/admin', 'Does not redirect');
   });
 });

--- a/tests/acceptance/build-results-test.js
+++ b/tests/acceptance/build-results-test.js
@@ -1,9 +1,10 @@
 import { findAll, click, currentURL, currentRouteName, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
+import { percySnapshot } from 'ember-percy';
 import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
 import findByText from '../helpers/find-by-text';
-import moment from 'moment';
 import login from 'ember-observer/tests/helpers/login';
+import moment from 'moment';
 
 module('Acceptance | build results', function(hooks) {
   setupEmberObserverTest(hooks);
@@ -144,7 +145,9 @@ module('Acceptance | build results', function(hooks) {
     await login();
     await visit('/admin/build-results');
     await click(findByText('.test-build-result a', 'details'));
-    
+
+    await percySnapshot('/admin/build-results');
+
     assert.equal(currentURL(), `/admin/build-results/${testResult.id}`);
   });
 

--- a/tests/acceptance/canary-test-results-test.js
+++ b/tests/acceptance/canary-test-results-test.js
@@ -1,0 +1,27 @@
+import { currentRouteName, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { percySnapshot } from 'ember-percy';
+import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
+import moment from 'moment';
+
+module('Acceptance | canary test results', function(hooks) {
+  setupEmberObserverTest(hooks);
+
+  test('redirects to current day', async function(assert) {
+    let addon = server.create('addon');
+
+    let addonVersion = server.create('version', { addonId: addon.id });
+
+    server.create('testResult', {
+      versionId: addonVersion.id,
+      canary: true,
+      createdAt: moment('2016-08-07 16:30').utc()
+    });
+
+    await visit('/canary-test-results');
+
+    await percySnapshot('/canary-test-results/date');
+
+    assert.equal(currentRouteName(), 'canary-test-results.date', 'transitions to canary test results date route');
+  });
+});

--- a/tests/acceptance/code-search-test.js
+++ b/tests/acceptance/code-search-test.js
@@ -1,5 +1,6 @@
 import { click, fillIn, findAll, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
+import { percySnapshot } from 'ember-percy';
 import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
 import findByText from '../helpers/find-by-text';
 
@@ -176,6 +177,8 @@ module('Acceptance | code search', function(hooks) {
     assert.ok(nameSortButton.querySelector('.icon-expand-less'));
 
     await click(usageSortButton);
+
+    await percySnapshot('/code-search');
 
     let resortedAddonNames = findAll('.test-addon-name');
     assert.dom(resortedAddonNames[0]).containsText('ember-foo', 'Addons are sorted descending by default for switch to usage count sort');

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -173,6 +173,19 @@ module('Acceptance: Index', function(hooks) {
     assert.equal(currentRouteName(), 'not-found');
   });
 
+  test('provides a link to the top addons', async function(assert) {
+    server.create('addon', { name: 'ember-a-thing' });
+    server.create('addon', { name: 'ember-test-me', description: 'A thin addon' });
+
+    await visit(`/?query=test`);
+
+    await click(findByText('.top-addons a', 'See all top 100 addons'));
+
+    await percySnapshot('/lists/top-addons');
+
+    assert.equal(currentURL(), '/lists/top-addons', 'link to top addons works');
+  });
+
   function testSearch(url, assertForContentOnUrl) {
     test(`visiting ${url} with a query`, async function(assert) {
       server.create('addon', { name: 'ember-a-thing' });

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,5 +1,6 @@
 import { click, fillIn, find, findAll, currentURL, currentRouteName, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
+import { percySnapshot } from 'ember-percy';
 import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
 import findByText from '../helpers/find-by-text';
 
@@ -32,6 +33,8 @@ module('Acceptance: Index', function(hooks) {
 
     await visit('/');
 
+    await percySnapshot('/index');
+
     assert.dom('.test-category').exists({ count: 8 }, 'All categories should display');
     assert.ok(findByText('.test-category', 'Authentication (5)'), 'Categories should list title and count of addons');
     let firstSubcategory = findAll('.test-subcategory')[0];
@@ -48,6 +51,8 @@ module('Acceptance: Index', function(hooks) {
 
     let simpleAuth = findByText('a', 'Simple Auth (1)');
     await click(simpleAuth);
+
+    await percySnapshot('/categories/show');
 
     assert.equal(currentURL(), '/categories/simple-auth', 'URL should use category name token');
     assert.dom('.test-category-header').containsText('Simple Auth', 'Header should display');

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -168,6 +168,8 @@ module('Acceptance: Index', function(hooks) {
   test('Unknown routes are handled', async function(assert) {
     await visit('/bullshit');
 
+    await percySnapshot('not-found');
+
     assert.equal(currentRouteName(), 'not-found');
   });
 

--- a/tests/acceptance/maintainers-test.js
+++ b/tests/acceptance/maintainers-test.js
@@ -1,5 +1,6 @@
 import { currentRouteName, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
+import { percySnapshot } from 'ember-percy';
 import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
 
 module('Acceptance: Maintainers', function(hooks) {
@@ -9,6 +10,8 @@ module('Acceptance: Maintainers', function(hooks) {
     server.create('maintainer', 1);
 
     await visit('/maintainers/maintainer-0');
+
+    await percySnapshot('/maintainers/show');
 
     assert.equal(currentRouteName(), 'maintainers.show');
   });

--- a/tests/acceptance/managing-build-servers-test.js
+++ b/tests/acceptance/managing-build-servers-test.js
@@ -1,8 +1,9 @@
 import { click, fillIn, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
+import { percySnapshot } from 'ember-percy';
 import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
-import login from '../helpers/login';
 import findByText from '../helpers/find-by-text'
+import login from '../helpers/login';
 
 module('Acceptance | managing build servers', function(hooks) {
   setupEmberObserverTest(hooks);
@@ -18,6 +19,8 @@ module('Acceptance | managing build servers', function(hooks) {
 
     await login();
     await visit('/admin/build-servers');
+
+    await percySnapshot('/admin/build-servers');
 
     assert.dom('.test-build-server-row').exists({ count: 15 });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,7 +2127,7 @@ base64-arraybuffer@0.1.5:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
   integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
@@ -2203,7 +2203,12 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.1.1, bluebird@^3.4.6, bluebird@^3.5.3:
+bluebird-retry@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/bluebird-retry/-/bluebird-retry-0.11.0.tgz#1289ab22cbbc3a02587baad35595351dd0c1c047"
+  integrity sha1-EomrIsu8OgJYe6rTVZU1HdDBwEc=
+
+bluebird@^3.1.1, bluebird@^3.4.6, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
   integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
@@ -3990,7 +3995,7 @@ ember-cli-babel-plugin-helpers@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.0.2.tgz#d4bec0f32febc530e621ea8d66d3365727cb5e6c"
   integrity sha512-tTWmHiIvadgtu0i+Zlb5Jnue69qO6dtACcddkRhhV+m9NfAr+2XNoTKRSeGL8QyRDhfWeo4rsK9dqPrU4PQ+8g==
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.18.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.18.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -4688,6 +4693,17 @@ ember-pad@1.2.3:
   dependencies:
     ember-cli-babel "^6.6.0"
 
+ember-percy@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/ember-percy/-/ember-percy-1.5.0.tgz#c70d66f7cdcc6078d2b7e18de04e545ac4da9818"
+  integrity sha512-wdGKo4gK40QeLXTcmmymk6kTe+8lpxW3vz46kuZIB6S1TzoyVpopE+4bDa9RyKP94b1kmJA0cepcW5npBH9xKQ==
+  dependencies:
+    body-parser "^1.15.0"
+    ember-cli-babel "^6.10.0"
+    es6-promise-pool "^2.4.1"
+    percy-client "^3.0.0"
+    walk "^2.3.9"
+
 ember-power-select-typeahead@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/ember-power-select-typeahead/-/ember-power-select-typeahead-0.7.3.tgz#30f7922b520a7e8ab1a0094b413235f7c09feae6"
@@ -4952,6 +4968,11 @@ es-to-primitive@^1.2.0:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es6-promise-pool@^2.4.1, es6-promise-pool@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz#147c612b36b47f105027f9d2bf54a598a99d9ccb"
+  integrity sha1-FHxhKza0fxBQJ/nSv1SlmKmdnMs=
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -5578,6 +5599,11 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+foreachasync@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/foreachasync/-/foreachasync-3.0.0.tgz#5502987dc8714be3392097f32e0071c9dee07cf6"
+  integrity sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -6848,6 +6874,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jssha@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/jssha/-/jssha-2.3.1.tgz#147b2125369035ca4b2f7d210dc539f009b3de9a"
+  integrity sha1-FHshJTaQNcpLL30hDcU58Amz3po=
 
 keyv@3.0.0:
   version "3.0.0"
@@ -8482,6 +8513,21 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+percy-client@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-3.0.4.tgz#3a516413769f4ade91f366c460fd50f2d000262b"
+  integrity sha512-IuJmspJ7T4fDm02cITvuugkb7FIvmEi2V+OoSY9pZjfdWBBnFo+ufVTYxI3d3lyNqJoYfd0XaTkejGhfr91erg==
+  dependencies:
+    base64-js "^1.2.3"
+    bluebird "^3.5.1"
+    bluebird-retry "^0.11.0"
+    es6-promise-pool "^2.5.0"
+    jssha "^2.1.0"
+    regenerator-runtime "^0.13.1"
+    request "^2.87.0"
+    request-promise "^4.2.2"
+    walk "^2.3.14"
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -8644,7 +8690,7 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.24:
+psl@^1.1.24, psl@^1.1.28:
   version "1.1.31"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
   integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
@@ -8696,7 +8742,7 @@ punycode@^1.2.4, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -8909,6 +8955,11 @@ regenerator-runtime@^0.12.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
+regenerator-runtime@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz#522ea2aafd9200a00eee143dc14219a35a0f3991"
+  integrity sha512-5KzMIyPLvfdPmvsdlYsHqITrDfK9k7bmvf97HvHSN4810i254ponbxCQ1NukpRWlu6en2MBWzAlhDExEKISwAA==
+
 regenerator-runtime@^0.9.5:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
@@ -9014,6 +9065,23 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
+
+request-promise-core@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
+  integrity sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==
+  dependencies:
+    lodash "^4.17.11"
+
+request-promise@^4.2.2:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.4.tgz#1c5ed0d71441e38ad58c7ce4ea4ea5b06d54b310"
+  integrity sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
 
 request@^2.87.0, request@^2.88.0:
   version "2.88.0"
@@ -9810,6 +9878,11 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
+stealthy-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -10205,6 +10278,14 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+tough-cookie@^2.3.3:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
 tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
@@ -10553,6 +10634,13 @@ walk-sync@^1.0.0:
     "@types/minimatch" "^3.0.3"
     ensure-posix-path "^1.1.0"
     matcher-collection "^1.1.1"
+
+walk@^2.3.14, walk@^2.3.9:
+  version "2.3.14"
+  resolved "https://registry.yarnpkg.com/walk/-/walk-2.3.14.tgz#60ec8631cfd23276ae1e7363ce11d626452e1ef3"
+  integrity sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==
+  dependencies:
+    foreachasync "^3.0.0"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
[Percy](https://percy.io/) is a visual testing tool designed to help catch regressions and reduce the amount of manual testing done in your application. 

With Percy's recent introduction of a [free plan](https://blog.percy.io/introducing-our-free-visual-testing-plan-2cd70a34d89d) and some important CSS changes [planned](https://github.com/emberobserver/client/issues/118) for Ember Observer, Percy now makes a lot of sense.

This PR:
- installs `ember-percy`, an ember addon used to easily integrate Percy into ember projects
- adds percy snapshots to some of the most commonly accessed pages of the application

## Notes
- `ember-percy` repo is [here](https://github.com/percy/ember-percy/).
- `PERCY_TOKEN` has already been added to the CI env so snapshots for master will hopefully just begin being taken once the PR merges.