### PR TITLE
Show dependent addons

### DIFF
--- a/app/components/dependency-table.js
+++ b/app/components/dependency-table.js
@@ -23,10 +23,6 @@ export default Component.extend({
     let { dependencies, devDependencies } = yield this.fetchData();
     this.set('dependencies',  dependencies);
     this.set('devDependencies',  devDependencies);
-  }),
-
-  uncollapse: task(function * () {
-    yield this.get('loadDependencies').perform();
     this.set('collapsed', false);
   }),
 

--- a/app/components/dependency-table.js
+++ b/app/components/dependency-table.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { isEmpty } from '@ember/utils';
 
@@ -11,18 +10,24 @@ export default Component.extend({
 
   showingAllDependencies: false,
 
-  store: service(),
+  collapsed: false,
 
   init() {
     this._super(...arguments);
-    this.get('fetchDependencies').perform();
+    if (!this.collapsed) {
+      this.get('loadDependencies').perform();
+    }
   },
 
-  fetchDependencies: task(function * () {
-    let addonVersionId = this.get('addonVersion.id');
-    let results = yield this.store.query('addon-dependency', { filter: { addonVersionId }, sort: 'package' });
-    this.set('dependencies',  results.filter((dep) => dep.isDependency));
-    this.set('devDependencies',  results.filter((dep) => dep.isDevDependency));
+  loadDependencies: task(function * () {
+    let { dependencies, devDependencies } = yield this.fetchData();
+    this.set('dependencies',  dependencies);
+    this.set('devDependencies',  devDependencies);
+  }),
+
+  uncollapse: task(function * () {
+    yield this.get('loadDependencies').perform();
+    this.set('collapsed', false);
   }),
 
   addonHasDependencies: computed('dependencies', 'devDependencies', function() {

--- a/app/components/dependency-tables.js
+++ b/app/components/dependency-tables.js
@@ -1,6 +1,9 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 
+const dependencies = (dep) => dep.isDependency;
+const devDependencies = (dep) => dep.isDevDependency;
+
 export default Component.extend({
   tagName: '',
 
@@ -15,8 +18,8 @@ export default Component.extend({
         sort: 'package',
       }).then((results) => {
         return {
-          dependencies: results.filter((dep) => dep.isDependency).map((dep) => dep.package),
-          devDependencies: results.filter((dep) => dep.isDevDependency).map((dep) => dep.package)
+          dependencies: results.filter(dependencies).map(dep => dep.package),
+          devDependencies: results.filter(devDependencies).map(dep => dep.package)
         };
       });
     },
@@ -27,8 +30,8 @@ export default Component.extend({
         include: 'dependent-version',
       }).then((results) => {
         return {
-          dependencies: results.filter(dep => dep.isDependency).map(dep => dep.dependentVersion.get('addonName')).sort(),
-          devDependencies: results.filter(dep => dep.isDevDependency).map(dep => dep.dependentVersion.get('addonName')).sort()
+          dependencies: results.filter(dependencies).map(dep => dep.dependentVersion.get('addonName')).sort(),
+          devDependencies: results.filter(devDependencies).map(dep => dep.dependentVersion.get('addonName')).sort()
         };
       });
     }

--- a/app/components/dependency-tables.js
+++ b/app/components/dependency-tables.js
@@ -1,0 +1,37 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+
+export default Component.extend({
+  tagName: '',
+
+  store: service(),
+
+  addonVersion: null,
+
+  actions: {
+    fetchDependencies(addonVersionId) {
+      return this.store.query('addon-dependency', {
+        filter: { addonVersionId },
+        sort: 'package',
+      }).then((results) => {
+        return {
+          dependencies: results.filter((dep) => dep.isDependency).map((dep) => dep.package),
+          devDependencies: results.filter((dep) => dep.isDevDependency).map((dep) => dep.package)
+        };
+      });
+    },
+
+    fetchDependents(packageAddonId) {
+      return this.store.query('addon-dependency', {
+        filter: { packageAddonId },
+        include: 'dependent-version',
+        sort: 'package',
+      }).then((results) => {
+        return {
+          dependencies: results.filter((dep) => dep.isDependency).map((dep) => dep.dependentVersion.get('addonName')),
+          devDependencies: results.filter((dep) => dep.isDevDependency).map((dep) => dep.dependentVersion.get('addonName'))
+        };
+      });
+    }
+  }
+});

--- a/app/components/dependency-tables.js
+++ b/app/components/dependency-tables.js
@@ -25,11 +25,10 @@ export default Component.extend({
       return this.store.query('addon-dependency', {
         filter: { packageAddonId },
         include: 'dependent-version',
-        sort: 'package',
       }).then((results) => {
         return {
-          dependencies: results.filter((dep) => dep.isDependency).map((dep) => dep.dependentVersion.get('addonName')),
-          devDependencies: results.filter((dep) => dep.isDevDependency).map((dep) => dep.dependentVersion.get('addonName'))
+          dependencies: results.filter(dep => dep.isDependency).map(dep => dep.dependentVersion.get('addonName')).sort(),
+          devDependencies: results.filter(dep => dep.isDevDependency).map(dep => dep.dependentVersion.get('addonName')).sort()
         };
       });
     }

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -4,6 +4,7 @@ import { belongsTo, hasMany } from 'ember-data/relationships';
 
 export default Model.extend({
   version: attr('string'),
+  addonName: attr('string'),
   released: attr('date'),
   emberCliVersion: attr('string'),
   addon: belongsTo('addon', { inverse: 'versions' }),

--- a/app/styles/components/_dependency-table.scss
+++ b/app/styles/components/_dependency-table.scss
@@ -1,5 +1,11 @@
 .addon-dependency-table {
 
+  .uncollapse {
+    font-weight: lighter;
+    display: block;
+    margin-top: .5rem;
+  }
+
   .description {
     &.no-addons {
       margin-top: .5rem;
@@ -32,7 +38,7 @@
       }
 
       th {
-        padding-bottom: .5rem;
+        padding-bottom: .25rem;
       }
 
       .version-dependency {

--- a/app/templates/addons/show.hbs
+++ b/app/templates/addons/show.hbs
@@ -78,8 +78,7 @@
     </section>
 
     <section class="addon-dependencies">
-      <h4>Dependencies</h4>
-      {{dependency-table addonVersion=latestVersion}}
+      {{dependency-tables addonVersion=latestVersion addon=addon}}
     </section>
 
     {{#if addon.readme}}

--- a/app/templates/components/dependency-table.hbs
+++ b/app/templates/components/dependency-table.hbs
@@ -1,8 +1,10 @@
 {{#if collapsed}}
-  {{#if uncollapse.isRunning}}
+  {{#if loadDependencies.isRunning}}
     <p class="uncollapse">{{dot-spinner}}</p>
+  {{else if loadDependencies.last.isError}}
+    <p class="uncollapse test-uncollapse-error">Unable to load addons</p>
   {{else}}
-    <a href="#" class="uncollapse test-show-dependents" {{action (perform uncollapse)}}>Show addons</a>
+    <a href="#" class="uncollapse test-show-dependents" {{action (perform loadDependencies)}}>Show addons</a>
   {{/if}}
 {{else}}
   {{#if addonHasDependencies}}

--- a/app/templates/components/dependency-table.hbs
+++ b/app/templates/components/dependency-table.hbs
@@ -1,60 +1,68 @@
-{{#if addonHasDependencies}}
-  <p class="description">Version {{addonVersion.version}} of this addon depends on the following addons:</p>
-  <div class="dependency-table">
-    <div>
-      <table class="version-dependencies test-dev-dependencies">
-        <tr>
-          <th>Dev Dependencies</th>
-        </tr>
-        {{#each devDependencies as |dependency index|}}
-          {{#if (or showingAllDependencies (lt index limit))}}
-            <tr>
-              <td class="test-dependency-name">
-                {{#link-to "addons.show" dependency.package}}{{dependency.package}}{{/link-to}}
-              </td>
-            </tr>
-          {{/if}}
-        {{else}}
-          <tr><td>None</td></tr>
-        {{/each}}
-        {{#if hasHiddenDevDependencies}}
-          <tr><td>...</td></tr>
-          <tr>
-            <td>
-              <a href="#" class="more test-show-all-dependencies" {{action (mut showingAllDependencies) true}}>Show {{hiddenDevDependencyCount}} more</a>
-            </td>
-          </tr>
-        {{/if}}
-      </table>
-    </div>
-    <div>
-      <table class="version-dependencies test-dependencies">
-        <tr>
-          <th>Dependencies</th>
-        </tr>
-        {{#each dependencies as |dependency index|}}
-          {{#if (or showingAllDependencies (lt index limit))}}
-            <tr>
-              <td class="test-dependency-name">
-                {{#link-to "addons.show" dependency.package}}{{dependency.package}}{{/link-to}}
-              </td>
-            </tr>
-          {{/if}}
-        {{else}}
-          <tr><td>None</td></tr>
-        {{/each}}
-        {{#if hasHiddenDependencies}}
-          <tr><td>...</td></tr>
-          <tr>
-            <td>
-              <a href="#" class="more test-show-all-dependencies" {{action (mut showingAllDependencies) true}}>Show {{hiddenDependencyCount}} more</a>
-            </td>
-          </tr>
-        {{/if}}
-      </table>
-    </div>
-  </div>
-  <hr>
+{{#if collapsed}}
+  {{#if uncollapse.isRunning}}
+    <p class="uncollapse">{{dot-spinner}}</p>
+  {{else}}
+    <a href="#" class="uncollapse test-show-dependents" {{action (perform uncollapse)}}>Show addons</a>
+  {{/if}}
 {{else}}
-  <p class="no-addons description test-no-addons-message">Version {{addonVersion.version}} of this addon does not depend on any other addons.</p>
+  {{#if addonHasDependencies}}
+    <p class="description">{{description}}</p>
+    <div class="dependency-table">
+      <div>
+        <table class="version-dependencies test-dev-dependencies">
+          <tr>
+            <th>Dev Dependencies</th>
+          </tr>
+          {{#each devDependencies as |dependency index|}}
+            {{#if (or showingAllDependencies (lt index limit))}}
+              <tr>
+                <td class="test-dependency-name">
+                  {{#link-to "addons.show" dependency}}{{dependency}}{{/link-to}}
+                </td>
+              </tr>
+            {{/if}}
+          {{else}}
+            <tr><td>None</td></tr>
+          {{/each}}
+          {{#if hasHiddenDevDependencies}}
+            <tr><td>...</td></tr>
+            <tr>
+              <td>
+                <a href="#" class="more test-show-all-dependencies" {{action (mut showingAllDependencies) true}}>Show {{hiddenDevDependencyCount}} more</a>
+              </td>
+            </tr>
+          {{/if}}
+        </table>
+      </div>
+      <div>
+        <table class="version-dependencies test-dependencies">
+          <tr>
+            <th>Dependencies</th>
+          </tr>
+          {{#each dependencies as |dependency index|}}
+            {{#if (or showingAllDependencies (lt index limit))}}
+              <tr>
+                <td class="test-dependency-name">
+                  {{#link-to "addons.show" dependency}}{{dependency}}{{/link-to}}
+                </td>
+              </tr>
+            {{/if}}
+          {{else}}
+            <tr><td>None</td></tr>
+          {{/each}}
+          {{#if hasHiddenDependencies}}
+            <tr><td>...</td></tr>
+            <tr>
+              <td>
+                <a href="#" class="more test-show-all-dependencies" {{action (mut showingAllDependencies) true}}>Show {{hiddenDependencyCount}} more</a>
+              </td>
+            </tr>
+          {{/if}}
+        </table>
+      </div>
+    </div>
+    <hr>
+  {{else}}
+    <p class="no-addons description test-no-addons-message">{{noAddonsMessage}}</p>
+  {{/if}}
 {{/if}}

--- a/app/templates/components/dependency-tables.hbs
+++ b/app/templates/components/dependency-tables.hbs
@@ -1,0 +1,16 @@
+<h4>Dependencies</h4>
+{{dependency-table
+    fetchData=(action "fetchDependencies" addonVersion.id)
+    collapsed=false
+    description=(concat "Version " addonVersion.version " of this addon depends on the following addons:")
+    noAddonsMessage=(concat "Version " addonVersion.version " of this addon does not depend on any other addons.")
+    class="test-addon-dependencies"
+}}
+<h4>Dependents</h4>
+{{dependency-table
+    fetchData=(action "fetchDependents" addon.id)
+    collapsed=true
+    description="This addon is a dependency of the current versions of the following addons:"
+    noAddonsMessage="No addons have a current version that depends on this addon."
+    class="test-addon-dependents"
+}}


### PR DESCRIPTION
Requires backend PR: https://github.com/emberobserver/server/pull/62

This adds a Dependents section to the addon page that lists non-hidden addons where the latest version has any version of this addon as a dependency. Dependent addon data is loaded when the 'Show addons' link is clicked.

- Make `dependency-table` component reusable for dependent addons. Add `dependency-tables` component that wraps a `dependency-table` each for dependencies and dependents.

- Add `addonName` property to `version` model.

- Upgrade qunit to access `setupOnerror` and `resetOnerror` methods.

Before loading:
![Screen Shot 2019-04-19 at 8 01 24 AM](https://user-images.githubusercontent.com/325967/56423886-fd332e00-627b-11e9-9f59-e1f2740aab70.png)

After loading:
![Screen Shot 2019-04-19 at 8 01 37 AM](https://user-images.githubusercontent.com/325967/56423885-fd332e00-627b-11e9-8acb-904de8988b32.png)

No dependents:
![Screen Shot 2019-04-19 at 8 04 19 AM](https://user-images.githubusercontent.com/325967/56423883-fd332e00-627b-11e9-9229-78ded208f49d.png)

Error loading:
![Screen Shot 2019-04-19 at 8 03 22 AM](https://user-images.githubusercontent.com/325967/56423884-fd332e00-627b-11e9-8158-07bbfdb457e0.png)

