### PR TITLE
s/Github/GitHub

### DIFF
--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -49,13 +49,13 @@
         <li>1 point is given for more than 1 commit within the last 3 months.</li>
         <li>1 point is given for having more than 1 contributor.</li>
         <li>1 point is given for having a download count in the last 30 days that is in the top 10% for all addons.</li>
-        <li>1 point is given for having a Github star count in the top 10% of all addons.</li>
+        <li>1 point is given for having a GitHub star count in the top 10% of all addons.</li>
         <li>The total score is out of 10.</li>
       </ul>
       <br>
       <p>
-        This score is far from perfect. Currently it is biased against any addon not hosted on Github or with an
-        incorrect repo url. To fix this we are thinking about averaging the Github-reliant portion of the score with
+        This score is far from perfect. Currently it is biased against any addon not hosted on GitHub or with an
+        incorrect repo url. To fix this we are thinking about averaging the GitHub-reliant portion of the score with
         portion provided by npm info and the review.
       </p>
 

--- a/app/templates/addons/show.hbs
+++ b/app/templates/addons/show.hbs
@@ -42,7 +42,7 @@
     </section>
     {{#if hasGithubData}}
       <section class="repo-info test-github-data">
-        <h4>Github</h4>
+        <h4>GitHub</h4>
 
         {{#if addon.isTopStarred}}
           <small>TOP 10% STARRED</small>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -12,7 +12,7 @@
     <p>
       Created by <a href="http://www.codeallday.com">Katie Gengler</a>, <a href="http://louissimons.com/">Louis Simons</a> and <a href="http://pgengler.net">Phil Gengler</a>.
     </p>
-    <p>An open source project hosted on <a href="https://github.com/emberobserver/client">Github</a></p>
+    <p>An open source project hosted on <a href="https://github.com/emberobserver/client">GitHub</a></p>
 
     {{!-- TrackJS Badge for error reporting  --}}
     <div>


### PR DESCRIPTION
This is a purely cosmetic change. It replaces all _visible_ references to Github (lowercase h) with GitHub (uppercase H) to stay on-brand with their name.