### PR TITLE
Remove accidental network request from test suite

### DIFF
--- a/app/routes/categories/show.js
+++ b/app/routes/categories/show.js
@@ -7,6 +7,9 @@ export default Route.extend({
   model(params) {
     return this.modelFor('application').categories.then(() => {
       let category = this.get('store').peekAll('category').findBy('slug', params.slug);
+      if (!category) {
+        throw new Error(`no such category ${params.slug}`);
+      }
       let addons = this.get('store').query('addon', { filter: { inCategory: category.get('id') }, include: 'categories' });
       return hash({
         category,

--- a/tests/acceptance/categories-test.js
+++ b/tests/acceptance/categories-test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
+
 
 module('Acceptance | categories', function(hooks) {
-  setupApplicationTest(hooks);
+  setupEmberObserverTest(hooks);
 
   test('trying to view a nonexistent category displays not-found content', async function(assert) {
     await visit('/categories/addons-that-violate-fundamental-laws-of-the-universe');


### PR DESCRIPTION
This test passes, but it does so in a way that's probably not what was intended:

1. The `application` route makes a *real* network request, which fails. 
2. The `categories.show` route tries to chain off that failed promise and gets the rejection.

That doesn't really test the case of a nonexistent category, it tests the case of being unable to load any categories.

This change activates mirage instead, so that a *fake* network request in the `application` route succeeds, and then the code within the `categories.show` route can get exercised and deal with the case where the category doesn't exist.

This error was harmless for users, but it's messing up my embroider testing because when we're lazy-loading the categories routes, the rejected promise in the `application` route goes un-observed long enough that RSVP treats it as an unhandled exception, which fails the test suite. (The actual promise dangles inside the POJO that is the `application` route's model, and nobody calls `then` on it until the `categories.show` route manages to get running.)