### PR TITLE
Handle JSON-formatted test output

### DIFF
--- a/app/components/build-result-output.js
+++ b/app/components/build-result-output.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { alias, equal } from '@ember/object/computed';
+import { equal, readOnly } from '@ember/object/computed';
 
 export default Component.extend({
   tagName: '',
@@ -11,5 +11,5 @@ export default Component.extend({
     return JSON.parse(this.buildResult.output);
   }),
 
-  groups: alias('parsedJSON')
+  groups: readOnly('parsedJSON')
 });

--- a/app/components/build-result-output.js
+++ b/app/components/build-result-output.js
@@ -3,6 +3,8 @@ import { computed } from '@ember/object';
 import { alias, equal } from '@ember/object/computed';
 
 export default Component.extend({
+  tagName: '',
+
   isJsonFormat: equal('buildResult.outputFormat', 'json'),
 
   parsedJSON: computed('buildResult.output', function() {

--- a/app/components/build-result-output.js
+++ b/app/components/build-result-output.js
@@ -1,0 +1,21 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+
+export default Component.extend({
+  isJsonFormat: computed('buildResult.output', function() {
+    try {
+      JSON.parse(this.buildResult.output);
+      return true;
+    }
+    catch (e) {
+      return false;
+    }
+  }),
+
+  parsedJSON: computed('buildResult.output', function() {
+    return JSON.parse(this.buildResult.output);
+  }),
+
+  groups: alias('parsedJSON')
+});

--- a/app/components/build-result-output.js
+++ b/app/components/build-result-output.js
@@ -1,17 +1,9 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { alias } from '@ember/object/computed';
+import { alias, equal } from '@ember/object/computed';
 
 export default Component.extend({
-  isJsonFormat: computed('buildResult.output', function() {
-    try {
-      JSON.parse(this.buildResult.output);
-      return true;
-    }
-    catch (e) {
-      return false;
-    }
-  }),
+  isJsonFormat: equal('buildResult.outputFormat', 'json'),
 
   parsedJSON: computed('buildResult.output', function() {
     return JSON.parse(this.buildResult.output);

--- a/app/components/test-result-status.js
+++ b/app/components/test-result-status.js
@@ -2,7 +2,8 @@ import { computed } from '@ember/object';
 import Component from '@ember/component';
 
 export default Component.extend({
-  classNames: ['test-result-status'],
+  tagName: '',
+
   statusText: computed('testResult.succeeded', 'testResult.emberVersionCompatibilities.firstObject.compatible', function() {
     if (this.get('testResult.succeeded')) {
       if (this.get('testResult.emberVersionCompatibilities.firstObject.compatible')) {

--- a/app/controllers/admin/build-results/show.js
+++ b/app/controllers/admin/build-results/show.js
@@ -1,13 +1,13 @@
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
-import { alias } from '@ember/object/computed';
+import { readOnly } from '@ember/object/computed';
 
 export default Controller.extend({
   ajax: service('apiAjax'),
-  buildResult: alias('model'),
-  addonVersion: alias('buildResult.version'),
-  addon: alias('addonVersion.addon'),
+  buildResult: readOnly('model'),
+  addonVersion: readOnly('buildResult.version'),
+  addon: readOnly('addonVersion.addon'),
   hasRetriedBuild: false,
 
   buildStatus: computed('buildResult.succeeded', 'buildResult.statusMessage', function() {

--- a/app/controllers/canary-test-results/date.js
+++ b/app/controllers/canary-test-results/date.js
@@ -1,10 +1,10 @@
 import { computed } from '@ember/object';
-import { alias } from '@ember/object/computed';
+import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import moment from 'moment';
 
 export default Controller.extend({
-  date: alias('model.date'),
+  date: readOnly('model.date'),
 
   formattedDisplayDate: computed('date', function() {
     return moment(this.get('date')).utc().format('YYYY-MM-DD');

--- a/app/controllers/canary-test-results/detail.js
+++ b/app/controllers/canary-test-results/detail.js
@@ -1,8 +1,8 @@
-import { alias } from '@ember/object/computed';
+import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-  testResult: alias('model'),
-  addonVersion: alias('testResult.version'),
-  addon: alias('addonVersion.addon')
+  testResult: readOnly('model'),
+  addonVersion: readOnly('testResult.version'),
+  addon: readOnly('addonVersion.addon')
 });

--- a/app/models/test-result.js
+++ b/app/models/test-result.js
@@ -7,6 +7,7 @@ export default DS.Model.extend({
   createdAt: DS.attr('date'),
   canary: DS.attr('boolean'),
   output: DS.attr('string'),
+  outputFormat: DS.attr('string'),
   semverString: DS.attr('string'),
 
   version: DS.belongsTo('version'),

--- a/app/models/test-result.js
+++ b/app/models/test-result.js
@@ -1,4 +1,4 @@
-import { alias } from '@ember/object/computed';
+import { readOnly } from '@ember/object/computed';
 import DS from 'ember-data';
 
 export default DS.Model.extend({
@@ -12,5 +12,5 @@ export default DS.Model.extend({
 
   version: DS.belongsTo('version'),
   emberVersionCompatibilities: DS.hasMany('emberVersionCompatibility'),
-  testsRunAt: alias('createdAt')
+  testsRunAt: readOnly('createdAt')
 });

--- a/app/styles/_admin_build_result.scss
+++ b/app/styles/_admin_build_result.scss
@@ -3,11 +3,17 @@
     line-height: 1;
   }
 
+  summary {
+    outline: none;
+  }
+
   details > details {
     font-family: monospace;
     margin-left: 25px;
 
     & > output {
+      display: block;
+      padding-left: 14px;
       white-space: pre;
     }
   }

--- a/app/styles/_admin_build_result.scss
+++ b/app/styles/_admin_build_result.scss
@@ -2,6 +2,15 @@
   pre {
     line-height: 1;
   }
+
+  details > details {
+    font-family: monospace;
+    margin-left: 25px;
+
+    & > output {
+      white-space: pre;
+    }
+  }
 }
 
 

--- a/app/styles/_admin_build_result.scss
+++ b/app/styles/_admin_build_result.scss
@@ -1,25 +1,3 @@
-.admin-build-result {
-  pre {
-    line-height: 1;
-  }
-
-  summary {
-    outline: none;
-  }
-
-  details > details {
-    font-family: monospace;
-    margin-left: 25px;
-
-    & > output {
-      display: block;
-      padding-left: 14px;
-      white-space: pre;
-    }
-  }
-}
-
-
 .admin-build-result-nav {
   text-align: center;
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -14,11 +14,12 @@
 @import "login";
 @import "addons_index";
 @import "addons-list";
-@import "components/large-search";
+@import "components/build-result-output";
 @import "components/code-search";
+@import "components/dependency-table";
+@import "components/large-search";
 @import "components/spinner";
 @import "components/toggle-switch";
-@import "components/dependency-table";
 @import "maintainers_show";
 @import "not_found";
 @import "button_select";

--- a/app/styles/components/_build-result-output.scss
+++ b/app/styles/components/_build-result-output.scss
@@ -1,0 +1,20 @@
+.build-result-output {
+  pre {
+    line-height: 1;
+  }
+
+  summary {
+    outline: none;
+  }
+
+  details > details {
+    font-family: monospace;
+    margin-left: 25px;
+
+    & > output {
+      display: block;
+      padding-left: 14px;
+      white-space: pre;
+    }
+  }
+}

--- a/app/templates/admin/build-results/show.hbs
+++ b/app/templates/admin/build-results/show.hbs
@@ -24,5 +24,5 @@
   </div>
 
   <h2>Output</h2>
-  <pre class="test-output">{{buildResult.output}}</pre>
+  <BuildResultOutput @buildResult={{buildResult}} />
 </div>

--- a/app/templates/canary-test-results/detail.hbs
+++ b/app/templates/canary-test-results/detail.hbs
@@ -13,5 +13,5 @@
   </div>
 
   <h2>Output</h2>
-  <BuildResultOutput @buildResult={{buildResult}} />
+  <BuildResultOutput @buildResult={{testResult}} />
 </div>

--- a/app/templates/canary-test-results/detail.hbs
+++ b/app/templates/canary-test-results/detail.hbs
@@ -13,5 +13,5 @@
   </div>
 
   <h2>Output</h2>
-  <pre class="test-output">{{testResult.output}}</pre>
+  <BuildResultOutput @buildResult={{buildResult}} />
 </div>

--- a/app/templates/components/build-result-output.hbs
+++ b/app/templates/components/build-result-output.hbs
@@ -1,3 +1,18 @@
-<pre class="test-output">
-  {{@buildResult.output}}
-</pre>
+{{#if isJsonFormat}}
+  {{#each groups as |group|}}
+    <section>
+      <header>{{group.group}}</header>
+
+      {{#each group.commands as |command|}}
+        <details>
+          <summary>{{command.command}}</summary>
+          {{command.output}}
+        </details>
+      {{/each}}
+    </section>
+  {{/each}}
+{{else}}
+  <pre class="test-output">
+    {{@buildResult.output}}
+  </pre>
+{{/if}}

--- a/app/templates/components/build-result-output.hbs
+++ b/app/templates/components/build-result-output.hbs
@@ -1,14 +1,16 @@
 {{#if isJsonFormat}}
   {{#each groups as |group|}}
     <section>
-      <header>{{group.group}}</header>
+      <details open={{group.has_failures}}>
+        <summary>{{group.group}}</summary>
 
-      {{#each group.commands as |command|}}
-        <details>
-          <summary>{{command.command}}</summary>
-          {{command.output}}
-        </details>
-      {{/each}}
+        {{#each group.commands as |command|}}
+          <details open={{command.failed}}>
+            <summary>{{command.command}}</summary>
+            <output>{{command.output}}</output>
+          </details>
+        {{/each}}
+      </details>
     </section>
   {{/each}}
 {{else}}

--- a/app/templates/components/build-result-output.hbs
+++ b/app/templates/components/build-result-output.hbs
@@ -5,8 +5,9 @@
         <summary>{{group.group}}</summary>
 
         {{#each group.commands as |command|}}
+          {{! template-lint-disable no-nested-interactive }}
           <details open={{command.failed}}>
-            <summary>{{command.command}}</summary>
+            <summary>{{command.command}} {{if command.elapsedTime (concat '(' command.elapsedTime 's)')}}</summary>
             <output>{{command.output}}</output>
           </details>
         {{/each}}

--- a/app/templates/components/build-result-output.hbs
+++ b/app/templates/components/build-result-output.hbs
@@ -1,0 +1,3 @@
+<pre class="test-output">
+  {{@buildResult.output}}
+</pre>

--- a/app/templates/components/build-result-output.hbs
+++ b/app/templates/components/build-result-output.hbs
@@ -1,21 +1,23 @@
-{{#if isJsonFormat}}
-  {{#each groups as |group|}}
-    <section>
-      <details open={{group.has_failures}}>
-        <summary>{{group.group}}</summary>
+<div class="build-result-output">
+  {{#if isJsonFormat}}
+    {{#each groups as |group|}}
+      <section>
+        <details open={{group.has_failures}}>
+          <summary>{{group.group}}</summary>
 
-        {{#each group.commands as |command|}}
-          {{! template-lint-disable no-nested-interactive }}
-          <details open={{command.failed}}>
-            <summary>{{command.command}} {{if command.elapsedTime (concat '(' command.elapsedTime 's)')}}</summary>
-            <output>{{command.output}}</output>
-          </details>
-        {{/each}}
-      </details>
-    </section>
-  {{/each}}
-{{else}}
-  <pre class="test-output">
-    {{@buildResult.output}}
-  </pre>
-{{/if}}
+          {{#each group.commands as |command|}}
+            {{! template-lint-disable no-nested-interactive }}
+            <details open={{command.failed}}>
+              <summary>{{command.command}} {{if command.elapsedTime (concat '(' command.elapsedTime 's)')}}</summary>
+              <output>{{command.output}}</output>
+            </details>
+          {{/each}}
+        </details>
+      </section>
+    {{/each}}
+  {{else}}
+    <pre class="test-output">
+      {{@buildResult.output}}
+    </pre>
+  {{/if}}
+</div>

--- a/app/templates/components/test-result-status.hbs
+++ b/app/templates/components/test-result-status.hbs
@@ -1,4 +1,6 @@
-<span class="status">{{statusText}}</span>
-{{#if statusDetail}}
-  <span class="status-detail">{{statusDetail}}</span>
-{{/if}}
+<span class="test-result-status">
+  <span class="status">{{statusText}}</span>
+  {{#if statusDetail}}
+    <span class="status-detail">{{statusDetail}}</span>
+  {{/if}}
+</span>

--- a/tests/integration/components/build-result-output-test.js
+++ b/tests/integration/components/build-result-output-test.js
@@ -15,19 +15,89 @@ module('Integration | Component | build-result-output', function(hooks) {
     assert.dom('pre').hasText("I'm a teapot!", 'renders output in a <pre> tag');
   });
 
-  test('renders output that is valid JSON', async function(assert) {
-    this.set('buildResult', {
-      output: JSON.stringify([
-        {
-          group: 'Group One',
-          commands: [
-            { command: 'ls', output: 'foo' },
-          ]
-        }
-      ])
-    });
-    await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
+  module('JSON-format test output', function() {
+    test('renders command groups', async function(assert) {
+      this.set('buildResult', {
+        output: JSON.stringify([
+          {
+            group: 'Group One',
+            commands: [
+              { command: 'ls', output: 'foo' },
+            ]
+          },
+          {
+            group: 'Group Two',
+            commands: [
+              { command: 'rmdir foo', output: 'rmdir: foo: Not a directory' }
+            ]
+          }
+        ])
+      });
+      await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
 
-    assert.dom(this.element).hasText('Hi');
+      assert.dom('section').exists({ count: 2 }, 'renders <section> tags for each group');
+    });
+
+    test('displays command group details', async function(assert) {
+      this.set('buildResult', {
+        output: JSON.stringify([
+          {
+            group: 'Group One',
+            commands: [
+              { command: 'ls', output: 'foo' },
+            ]
+          }
+        ])
+      });
+      await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
+
+      assert.dom('section > details > summary').hasText('Group One', 'displays group header');
+      assert.dom('section > details > details > summary').hasText('ls', 'displays command in a <summary>');
+      assert.dom('section > details > details > output').hasText('foo', 'displays command output as an <output>');
+    });
+
+    test('command element displays as open when command was not successful', async function(assert) {
+      this.set('buildResult', {
+        output: JSON.stringify([
+          {
+            group: 'Group One',
+            commands: [
+              { command: 'ls foo', output: 'ls: foo: No such file or directory', failed: true }
+            ]
+          }
+        ])
+      });
+      await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
+
+      assert.dom('section > details > details').hasAttribute('open');
+    });
+
+    test('when a group has has_failures: true, that group is open by default', async function(assert) {
+      this.set('buildResult', {
+        output: JSON.stringify([
+          {
+            group: 'Group One',
+            has_failures: true
+          }
+        ])
+      });
+      await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
+
+      assert.dom('section > details').hasAttribute('open');
+    });
+
+    test('when a group has has_failures: false, that group is not open by default', async function(assert) {
+      this.set('buildResult', {
+        output: JSON.stringify([
+          {
+            group: 'Group One',
+            has_failures: false
+          }
+        ])
+      });
+      await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
+
+      assert.dom('section > details').doesNotHaveAttribute('open');
+    });
   });
 });

--- a/tests/integration/components/build-result-output-test.js
+++ b/tests/integration/components/build-result-output-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | build-result-output', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders build result output', async function(assert) {
+    this.set('buildResult', {
+      output: "I'm a teapot!"
+    });
+    await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
+
+    assert.dom('pre').hasText("I'm a teapot!", 'renders output in a <pre> tag');
+  });
+});

--- a/tests/integration/components/build-result-output-test.js
+++ b/tests/integration/components/build-result-output-test.js
@@ -6,9 +6,10 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | build-result-output', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders build result output as preformatted text when it is not valid JSON', async function(assert) {
+  test('it renders build result output as preformatted text when its format is "text"', async function(assert) {
     this.set('buildResult', {
-      output: "I'm a teapot!"
+      output: "I'm a teapot!",
+      outputFormat: 'text'
     });
     await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
 
@@ -31,7 +32,8 @@ module('Integration | Component | build-result-output', function(hooks) {
               { command: 'rmdir foo', output: 'rmdir: foo: Not a directory' }
             ]
           }
-        ])
+        ]),
+        outputFormat: 'json',
       });
       await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
 
@@ -47,7 +49,8 @@ module('Integration | Component | build-result-output', function(hooks) {
               { command: 'ls', output: 'foo' },
             ]
           }
-        ])
+        ]),
+        outputFormat: 'json'
       });
       await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
 
@@ -65,7 +68,8 @@ module('Integration | Component | build-result-output', function(hooks) {
               { command: 'ls foo', output: 'ls: foo: No such file or directory', failed: true }
             ]
           }
-        ])
+        ]),
+        outputFormat: 'json'
       });
       await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
 
@@ -79,7 +83,8 @@ module('Integration | Component | build-result-output', function(hooks) {
             group: 'Group One',
             has_failures: true
           }
-        ])
+        ]),
+        outputFormat: 'json'
       });
       await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
 
@@ -93,7 +98,8 @@ module('Integration | Component | build-result-output', function(hooks) {
             group: 'Group One',
             has_failures: false
           }
-        ])
+        ]),
+        outputFormat: 'json'
       });
       await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
 

--- a/tests/integration/components/build-result-output-test.js
+++ b/tests/integration/components/build-result-output-test.js
@@ -6,12 +6,28 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | build-result-output', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders build result output', async function(assert) {
+  test('it renders build result output as preformatted text when it is not valid JSON', async function(assert) {
     this.set('buildResult', {
       output: "I'm a teapot!"
     });
     await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
 
     assert.dom('pre').hasText("I'm a teapot!", 'renders output in a <pre> tag');
+  });
+
+  test('renders output that is valid JSON', async function(assert) {
+    this.set('buildResult', {
+      output: JSON.stringify([
+        {
+          group: 'Group One',
+          commands: [
+            { command: 'ls', output: 'foo' },
+          ]
+        }
+      ])
+    });
+    await render(hbs`<BuildResultOutput @buildResult={{buildResult}} />`);
+
+    assert.dom(this.element).hasText('Hi');
   });
 });


### PR DESCRIPTION
This updates the frontend to handle JSON-formatted test result data (see https://github.com/emberobserver/server/pull/66). This allows the result data to be displayed in a nested/collapsible form, with output grouped to the command that generated it. The styling could use some work but I don't think it's any worse than what we're doing currently.