### PR TITLE
add "total score" and average score to maintainers page

### DIFF
--- a/app/components/total-score.hbs
+++ b/app/components/total-score.hbs
@@ -1,0 +1,1 @@
+Total Score: {{this.score}} Average Score: {{this.averageScore}}

--- a/app/components/total-score.js
+++ b/app/components/total-score.js
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+
+export default class TotalScoreComponent extends Component {
+  get score() {
+    if(!this.args.addons.length) {
+      return 0;
+    }
+
+    let score = this.args.addons.reduce((total, currentAddon) => {
+      return currentAddon.score + total;
+    }, 0);
+
+    return score.toFixed(1);
+  }
+
+  get averageScore() {
+    if (!this.score || !this.args.addons.length){
+      return 0;
+    }
+
+    let average = this.score / this.args.addons.length;
+    return average.toFixed(1);
+  }
+}

--- a/app/templates/maintainers/show.hbs
+++ b/app/templates/maintainers/show.hbs
@@ -5,6 +5,7 @@
       {{this.model.name}}
     </h1>
     <p>{{pluralize-this this.model.addons.length "addon"}} maintained by {{this.model.name}}.</p>
+    <TotalScore @addons={{this.model.addons}} />
   </header>
   <AddonList @addons={{this.model.addons}} />
 </div>


### PR DESCRIPTION
This PR is mostly to open up a discussion, the styling of the change isn't ready to be merged and I'm not even sure it's something that we would want to add 😂 

Anyway, I saw someone share https://emberobserver.com/maintainers/rwjblue in the Community Discord and I thought "wow that is an impressive number of addons, but the number isn't big enough" 😂 so I thought a better metric would be to count up all the Ember Observer "points" that he has from each of the addons.

<img width="1546" alt="Screenshot 2020-02-26 at 08 03 24" src="https://user-images.githubusercontent.com/594890/75324294-863ccd80-586e-11ea-9301-b07c4192c444.png">

I also thought this might serve as a slight gamification (especially with the average score) that might encourage more maintainers to update their addons, but I don't know 🤷‍♂ 

(also for the record @rwjblue does not need gamification to make him do more 🙈) 