### PR TITLE
Show addon dependency sizes

### DIFF
--- a/app/components/dependency-size.js
+++ b/app/components/dependency-size.js
@@ -1,0 +1,29 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action, get } from '@ember/object';
+
+export default class DependencySizeComponent extends Component {
+  @tracked isViewingDetails;
+  @tracked isViewingOtherAssets;
+  @tracked addonSize;
+
+  get shouldShow() {
+    let addonSize = this.args.addonSize;
+    return addonSize && get(addonSize, 'totalSize') > 0;
+  }
+
+  @action
+  toggleDetail(e) {
+    e.preventDefault();
+    this.isViewingDetails = !this.isViewingDetails;
+    if (!this.isViewingDetails) {
+      this.isViewingOtherAssets = false;
+    }
+  }
+
+  @action
+  toggleOtherAssets(e) {
+    e.preventDefault();
+    this.isViewingOtherAssets = !this.isViewingOtherAssets;
+  }
+}

--- a/app/components/dependency-table.hbs
+++ b/app/components/dependency-table.hbs
@@ -18,8 +18,8 @@
           {{#each this.devDependencies as |dependency index|}}
             {{#if (or this.showingAllDependencies (lt index this.limit))}}
               <tr>
-                <td class="test-dependency-name">
-                  <LinkTo @route="addons.show" @model={{dependency}}>{{dependency}}</LinkTo>
+                <td class="test-dev-dependency-{{dependency.packageName}}">
+                  <LinkTo @route="addons.show" @model={{dependency.packageName}} class="test-dependency-name">{{dependency.packageName}}</LinkTo>
                 </td>
               </tr>
             {{/if}}
@@ -44,8 +44,11 @@
           {{#each this.dependencies as |dependency index|}}
             {{#if (or this.showingAllDependencies (lt index this.limit))}}
               <tr>
-                <td class="test-dependency-name">
-                  <LinkTo @route="addons.show" @model={{dependency}}>{{dependency}}</LinkTo>
+                <td class="test-dependency-{{dependency.packageName}}">
+                  <LinkTo @route="addons.show" @model={{dependency.packageName}} class="test-dependency-name">{{dependency.packageName}}</LinkTo>
+                  {{#if dependency.size}}
+                    <DependencySize @addonSize={{dependency.size}} />
+                  {{/if}}
                 </td>
               </tr>
             {{/if}}

--- a/app/components/dependency-tables.js
+++ b/app/components/dependency-tables.js
@@ -19,11 +19,12 @@ export default class DependencyTables extends Component {
   fetchDependencies(addonVersionId) {
     return this.store.query('addon-dependency', {
       filter: { addonVersionId },
+      include: 'package-addon.latest-addon-version.addon-size',
       sort: 'package',
     }).then((results) => {
       return {
-        dependencies: results.filter(dependencies).map(dep => dep.package),
-        devDependencies: results.filter(devDependencies).map(dep => dep.package)
+        dependencies: results.filter(dependencies).map(dep => dependencyObject(dep)),
+        devDependencies: results.filter(devDependencies).map(dep => dependencyObject(dep))
       };
     });
   }
@@ -35,9 +36,17 @@ export default class DependencyTables extends Component {
       include: 'dependent-version',
     }).then((results) => {
       return {
-        dependencies: results.filter(dependencies).map(dep => dep.dependentVersion.get('addonName')).sort(),
-        devDependencies: results.filter(devDependencies).map(dep => dep.dependentVersion.get('addonName')).sort()
+        dependencies: results.filter(dependencies).map(dep => dependentObject(dep)).sortBy('packageName'),
+        devDependencies: results.filter(devDependencies).map(dep => dependentObject(dep)).sortBy('packageName')
       };
     });
   }
+}
+
+function dependencyObject(dependency) {
+  return { packageName: dependency.get('package'), size: dependency.get('addonSize') };
+}
+
+function dependentObject(dependency) {
+  return { packageName: dependency.get('dependentVersion.addonName'), size: null };
 }

--- a/app/helpers/format-bytes.js
+++ b/app/helpers/format-bytes.js
@@ -1,0 +1,24 @@
+import { helper } from '@ember/component/helper';
+import { isEmpty } from '@ember/utils';
+
+export function formatBytes([number]/*, hash*/) {
+  if (isEmpty(number)) {
+    return '';
+  }
+  if (number >= Math.pow(1024, 3)) {
+    return format(number, Math.pow(1024, 3), 'GB');
+  }
+  if (number >= Math.pow(1024, 2)) {
+    return format(number, Math.pow(1024, 2), 'MB');
+  }
+  if (number >= 1024) {
+    return format(number, 1024, 'KB');
+  }
+  return `${number} B`;
+}
+
+function format(number, denominator, unit) {
+  return `${parseFloat((number / denominator).toFixed(2))} ${unit}`
+}
+
+export default helper(formatBytes);

--- a/app/models/addon-dependency.js
+++ b/app/models/addon-dependency.js
@@ -1,5 +1,5 @@
 import classic from 'ember-classic-decorator';
-import { equal } from '@ember/object/computed';
+import { equal, readOnly } from '@ember/object/computed';
 import Model, { belongsTo, attr } from '@ember-data/model';
 
 @classic
@@ -13,9 +13,15 @@ export default class AddonDependency extends Model {
   @belongsTo('version')
   dependentVersion;
 
+  @belongsTo('addon')
+  packageAddon;
+
   @equal('dependencyType', 'dependencies')
   isDependency;
 
   @equal('dependencyType', 'devDependencies')
   isDevDependency;
+
+  @readOnly('packageAddon.latestAddonVersion.addonSize')
+  addonSize;
 }

--- a/app/models/addon-size.js
+++ b/app/models/addon-size.js
@@ -1,6 +1,7 @@
 import classic from 'ember-classic-decorator';
 import { computed } from '@ember/object';
 import Model, { belongsTo, attr } from '@ember-data/model';
+import normalizeFingerprintedAsset from 'ember-observer/utils/normalize-fingerprinted-asset';
 
 @classic
 export default class AddonSize extends Model {
@@ -11,10 +12,22 @@ export default class AddonSize extends Model {
   appCssSize;
 
   @attr('number')
+  appJsGzipSize;
+
+  @attr('number')
+  appCssGzipSize;
+
+  @attr('number')
   vendorJsSize;
 
   @attr('number')
   vendorCssSize;
+
+  @attr('number')
+  vendorJsGzipSize;
+
+  @attr('number')
+  vendorCssGzipSize;
 
   @attr('number')
   otherJsSize;
@@ -22,16 +35,71 @@ export default class AddonSize extends Model {
   @attr('number')
   otherCssSize;
 
+  @attr('number')
+  otherJsGzipSize;
+
+  @attr('number')
+  otherCssGzipSize;
+
+  @attr()
+  otherAssets;
+
   @belongsTo('version')
   addonVersion;
+
+  @computed('otherJsSize', 'otherCssSize')
+  get otherAssetsSize() {
+    return this.otherJsSize + this.otherCssSize;
+  }
+
+  @computed('otherJsGzipSize', 'otherCssGzipSize')
+  get otherAssetsGzipSize() {
+    return this.otherJsGzipSize + this.otherCssGzipSize;
+  }
 
   @computed('appJsSize', 'vendorJsSize', 'otherJsSize')
   get totalJsSize() {
     return this.appJsSize + this.vendorJsSize + this.otherJsSize;
   }
 
+  @computed('appJsGzipSize', 'vendorJsGzipSize', 'otherJsGzipSize')
+  get totalJsGzipSize() {
+    return this.appJsGzipSize + this.vendorJsGzipSize + this.otherJsGzipSize;
+  }
+
   @computed('appCssSize', 'vendorCssSize', 'otherJCssSize')
   get totalCssSize() {
     return this.appCssSize + this.vendorCssSize + this.otherCssSize;
+  }
+
+  @computed('appCssGzipSize', 'vendorCssGzipSize', 'otherCssGzipSize')
+  get totalCssGzipSize() {
+    return this.appCssGzipSize + this.vendorCssGzipSize + this.otherCssGzipSize;
+  }
+
+  @computed('totalJsSize', 'totalCssSize')
+  get totalSize() {
+    return this.totalJsSize + this.totalCssSize;
+  }
+
+  @computed('totalJsGzipSize', 'totalCssGzipSize')
+  get totalGzipSize() {
+    return this.totalJsGzipSize + this.totalCssGzipSize;
+  }
+
+  @computed('otherAssets')
+  get hasOtherAssetsFiles() {
+    return this.otherAssets.files && this.otherAssets.files.length > 0;
+  }
+
+  @computed('otherAssets')
+  get normalizedOtherAssetFiles() {
+    return this.otherAssets.files.map(function(f) {
+      return {
+        name: normalizeFingerprintedAsset(f.name),
+        size: f.size,
+        gzipSize: f.gzipSize
+      };
+    });
   }
 }

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -21,6 +21,9 @@ export default class Version extends Model {
   @belongsTo('review')
   review;
 
+  @belongsTo('addon-size')
+  addonSize;
+
   @hasMany('addon-dependency')
   dependencies;
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -31,6 +31,7 @@
 @import "canary_test_results";
 @import "admin_review";
 @import "components/date-nav";
+@import "components/dependency-size";
 
 ::-ms-clear {
   display: none;

--- a/app/styles/components/_dependency-size.scss
+++ b/app/styles/components/_dependency-size.scss
@@ -1,0 +1,57 @@
+.dependency-size {
+
+  .toggle-detail {
+    margin-left: 4px;
+    cursor: pointer;
+    font-family: monospace;
+  }
+
+  .size-detail {
+    font-family: monospace;
+    margin: 6px 0;
+
+    @include media($small-screen) {
+      margin: 10px;
+    }
+  }
+
+  .totals {
+    font-weight: bold;
+  }
+
+  .row {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    width: 100%;
+    margin: 8px 0;
+
+    @include media($small-screen) {
+      margin: 2px 0;
+
+      &.other-assets {
+        padding-left: 10px;
+      }
+    }
+  }
+
+  .column-1 {
+    display: flex;
+    flex-basis: 120px;
+  }
+
+  .column-2 {
+    display: flex;
+    flex-basis: 100%;
+    flex-direction: column;
+    flex: 1;
+
+    @include media($small-screen) {
+      flex-direction: row;
+      .asset-size {
+        padding-left: .5rem;
+      }
+    }
+  }
+
+}

--- a/app/templates/components/dependency-size.hbs
+++ b/app/templates/components/dependency-size.hbs
@@ -1,0 +1,71 @@
+{{#if this.shouldShow}}
+  <span class="dependency-size">
+    <a role="button" href="#" {{on "click" this.toggleDetail}} class="test-size-summary toggle-detail">
+      {{format-bytes @addonSize.totalSize}} ({{format-bytes @addonSize.totalGzipSize}} gzipped) {{svg-icon (if this.isViewingDetails "expand-less" "expand-more")}}
+    </a>
+
+    {{#if this.isViewingDetails}}
+      <div class="size-detail test-size-detail">
+        {{#if @addonSize.appJsSize}}
+          <div class="row">
+            <div class="column-1">App JS:</div>
+            <div class="column-2 test-app-js">{{format-bytes @addonSize.appJsSize}} <span class="asset-size">({{format-bytes @addonSize.appJsGzipSize}} gzipped)</span></div>
+          </div>
+        {{/if}}
+        {{#if @addonSize.appCssSize}}
+          <div class="row">
+            <div class="column-1">App CSS:</div>
+            <div class="column-2 test-app-css">{{format-bytes @addonSize.appCssSize}} <span class="asset-size">({{format-bytes @addonSize.appCssGzipSize}} gzipped)</span></div>
+          </div>
+        {{/if}}
+        {{#if @addonSize.vendorJsSize}}
+          <div class="row">
+            <div class="column-1">Vendor JS:</div>
+            <div class="column-2 test-vendor-js">{{format-bytes @addonSize.vendorJsSize}} <span class="asset-size">({{format-bytes @addonSize.vendorJsGzipSize}} gzipped)</span></div>
+          </div>
+        {{/if}}
+        {{#if @addonSize.vendorCssSize}}
+          <div class="row">
+            <div class="column-1">Vendor CSS:</div>
+            <div class="column-2 test-vendor-css">{{format-bytes @addonSize.vendorCssSize}} <span class="asset-size">({{format-bytes @addonSize.vendorCssGzipSize}} gzipped)</span></div>
+          </div>
+        {{/if}}
+        {{#if @addonSize.otherAssetsSize}}
+          <div class="row">
+            <div class="column-1">Other Assets:</div>
+            <div class="column-2 test-other-assets">{{format-bytes @addonSize.otherAssetsSize}}
+              <span class="asset-size">
+                ({{format-bytes @addonSize.otherAssetsGzipSize}} gzipped)
+                {{#if @addonSize.hasOtherAssetsFiles}}
+                  <a role="button" href="#" class="test-other-assets-toggle toggle-detail" {{on "click" this.toggleOtherAssets}}>
+                    {{svg-icon (if this.isViewingOtherAssets "expand-less" "expand-more")}}
+                  </a>
+                {{/if}}
+              </span>
+            </div>
+          </div>
+        {{/if}}
+        {{#if this.isViewingOtherAssets}}
+          {{#each @addonSize.normalizedOtherAssetFiles as |file|}}
+            <div class="row other-assets test-other-assets-details">
+              <div class="column-1 test-asset-name">- {{file.name}}:</div>
+              <div class="column-2 test-asset-size">{{format-bytes file.size}} <span class="asset-size">({{format-bytes file.gzipSize}} gzipped)</span></div>
+            </div>
+          {{/each}}
+        {{/if}}
+        {{#if @addonSize.totalJsSize}}
+          <div class="row totals">
+            <div class="column-1">Total JS:</div>
+            <div class="column-2 test-total-js">{{format-bytes @addonSize.totalJsSize}} <span class="asset-size">({{format-bytes @addonSize.totalJsGzipSize}} gzipped)</span></div>
+          </div>
+        {{/if}}
+        {{#if @addonSize.totalCssSize}}
+          <div class="row totals">
+            <div class="column-1">Total CSS:</div>
+            <div class="column-2 test-total-css">{{format-bytes @addonSize.totalCssSize}} <span class="asset-size">({{format-bytes @addonSize.totalCssGzipSize}} gzipped)</span></div>
+          </div>
+        {{/if}}
+      </div>
+    {{/if}}
+  </span>
+{{/if}}

--- a/app/utils/normalize-fingerprinted-asset.js
+++ b/app/utils/normalize-fingerprinted-asset.js
@@ -1,0 +1,16 @@
+const FILENAME_REGEX = /([^/]+)(\.|-)\w+\.([^.]+)$/;
+
+export default function normalizeFingerprintedAsset(originalFilename) {
+  if (!originalFilename) {
+    return '';
+  }
+
+  let filenameParts = originalFilename.match(FILENAME_REGEX);
+  let normalizedFilename = originalFilename;
+
+  if (filenameParts && filenameParts.length >= 3) {
+    normalizedFilename = `${filenameParts[1]}.${filenameParts[3]}`;
+  }
+
+  return normalizedFilename;
+}

--- a/mirage/factories/addon-size.js
+++ b/mirage/factories/addon-size.js
@@ -1,0 +1,29 @@
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
+
+export default Factory.extend({
+  appJsSize: () => faker.random.number(),
+  appCssSize: () => faker.random.number(),
+
+  vendorJsSize: () => faker.random.number(),
+  vendorCssSize: () => faker.random.number(),
+
+  otherJsSize: () => faker.random.number(),
+  otherCssSize: () => faker.random.number(),
+
+  appJsGzipSize: () => faker.random.number(),
+  appCssGzipSize: () => faker.random.number(),
+
+  vendorJsGzipSize: () => faker.random.number(),
+  vendorCssGzipSize: () => faker.random.number(),
+
+  otherJsGzipSize: () => faker.random.number(),
+  otherCssGzipSize: () => faker.random.number(),
+
+  otherAssets() {
+    let empty = {
+      files: []
+    };
+    return JSON.stringify(empty);
+  }
+});

--- a/mirage/models/addon-dependency.js
+++ b/mirage/models/addon-dependency.js
@@ -1,5 +1,6 @@
 import { Model, belongsTo } from 'ember-cli-mirage';
 
 export default Model.extend({
-  dependentVersion: belongsTo('version')
+  dependentVersion: belongsTo('version'),
+  packageAddon: belongsTo('addon')
 });

--- a/mirage/models/addon-size.js
+++ b/mirage/models/addon-size.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/mirage/models/version.js
+++ b/mirage/models/version.js
@@ -3,6 +3,7 @@ import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 export default Model.extend({
   addon: belongsTo('addon', { inverse: 'versions' }),
   review: belongsTo(),
+  addonSize: belongsTo(),
   testResults: hasMany(),
   dependencies: hasMany('addon-dependency')
 });

--- a/tests/integration/components/dependency-size-test.js
+++ b/tests/integration/components/dependency-size-test.js
@@ -1,0 +1,223 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, findAll } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | dependency-size', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('renders size summary', async function(assert) {
+    let addonSize = {
+      totalSize: 2048,
+      totalGzipSize: 900,
+    };
+
+    this.set('addonSize', addonSize);
+
+    await render(hbs`<DependencySize @addonSize={{addonSize}}/>`);
+
+    assert.dom('.test-size-summary').exists();
+    assert.dom('.test-size-summary').hasText('2 KB (900 B gzipped)', 'Shows size summary');
+  });
+
+  test('renders size details when expanded', async function(assert) {
+    let addonSize = {
+      appJsSize: 1024,
+      appJsGzipSize: 400,
+
+      appCssSize: 800,
+      appCssGzipSize: 200,
+
+      vendorJsSize: 1536,
+      vendorJsGzipSize: 900,
+
+      vendorCssSize: 2048,
+      vendorCssGzipSize: 1000,
+
+      otherAssetsSize: 1836,
+      otherAssetsGzipSize: 1100,
+
+      totalJsSize: 3200,
+      totalJsGzipSize: 1500,
+
+      totalCssSize: 3000,
+      totalCssGzipSize: 1200,
+
+      totalSize: 6000,
+      totalGzipSize: 2080,
+    };
+
+    this.set('addonSize', addonSize);
+
+    await render(hbs`<DependencySize @addonSize={{addonSize}}/>`);
+
+    assert.dom('.test-size-detail').doesNotExist('Does not show detail before expanding');
+
+    await click('.test-size-summary');
+
+    assert.dom('.test-size-detail').exists('Shows detail after expanding');
+
+    assert.dom('.test-app-js').hasText('1 KB (400 B gzipped)');
+    assert.dom('.test-app-css').hasText('800 B (200 B gzipped)');
+    assert.dom('.test-vendor-js').hasText('1.5 KB (900 B gzipped)');
+    assert.dom('.test-vendor-css').hasText('2 KB (1000 B gzipped)');
+    assert.dom('.test-other-assets').hasText('1.79 KB (1.07 KB gzipped)');
+    assert.dom('.test-total-js').hasText('3.13 KB (1.46 KB gzipped)');
+    assert.dom('.test-total-css').hasText('2.93 KB (1.17 KB gzipped)');
+
+    await click('.test-size-summary');
+
+    assert.dom('.test-size-detail').doesNotExist('Detail gone after collapsing');
+  });
+
+  test('skips rows that have 0 size', async function(assert) {
+    let addonSize = {
+      appJsSize: 1024,
+      appJsGzipSize: 400,
+
+      totalJsSize: 3200,
+      totalJsGzipSize: 1500,
+
+      totalSize: 6000,
+      totalGzipSize: 2080,
+    };
+
+    this.set('addonSize', addonSize);
+
+    await render(hbs`<DependencySize @addonSize={{addonSize}}/>`);
+
+    assert.dom('.test-size-detail').doesNotExist('Does not show detail before expanding');
+
+    await click('.test-size-summary');
+
+    assert.dom('.test-size-detail').exists('Shows detail after expanding');
+
+    assert.dom('.test-app-js').hasText('1 KB (400 B gzipped)');
+    assert.dom('.test-total-js').hasText('3.13 KB (1.46 KB gzipped)');
+
+    assert.dom('.test-app-css').doesNotExist('Does not show row if size is 0');
+    assert.dom('.test-vendor-js').doesNotExist('Does not show row if size is 0');
+    assert.dom('.test-vendor-css').doesNotExist('Does not show row if size is 0');
+    assert.dom('.test-other-js').doesNotExist('Does not shfilow row if size is 0');
+    assert.dom('.test-other-assets').doesNotExist('Does not show row if size is 0');
+
+    await click('.test-size-summary');
+  });
+
+  test('does not show if no addon size given', async function(assert) {
+    this.set('addonSize', null);
+
+    await render(hbs`<DependencySize @addonSize={{addonSize}}/>`);
+
+    assert.dom('.test-size-summary').doesNotExist('Does not show summary if no addon size');
+  });
+
+  test('does now show if total size is 0', async function(assert) {
+    let addonSize = {
+      totalSize: 0,
+      totalGzipSize: 20,
+    };
+
+    this.set('addonSize', addonSize);
+
+    await render(hbs`<DependencySize @addonSize={{addonSize}}/>`);
+
+    assert.dom('.test-size-summary').doesNotExist('Does not show summary if addon size is 0');
+  });
+
+  test('can view other asset files', async function (assert) {
+    let addonSize = {
+      appJsSize: 1024,
+      appJsGzipSize: 400,
+
+      otherAssetsSize: 1836,
+      otherAssetsGzipSize: 1100,
+
+      totalJsSize: 3200,
+      totalJsGzipSize: 1500,
+
+      totalSize: 6000,
+      totalGzipSize: 2080,
+
+      normalizedOtherAssetFiles: [
+        {
+          name: 'auto-import-fastboot.js',
+          size: 57729,
+          gzipSize: 16869
+        },
+        {
+          name: 'chunk.js',
+          size: 57729,
+          gzipSize: 16869
+        },
+      ],
+
+      hasOtherAssetsFiles: true,
+    };
+
+    this.set('addonSize', addonSize);
+
+    await render(hbs`<DependencySize @addonSize={{addonSize}}/>`);
+
+    await click('.test-size-summary');
+
+    assert.dom('.test-other-assets-details').doesNotExist('Does not show other assets by default');
+
+    await click('.test-other-assets-toggle');
+
+    let otherAssetsDetails = findAll('.test-other-assets-details');
+    assert.equal(otherAssetsDetails.length, 2, 'Shows each asset file');
+
+    assert.dom(otherAssetsDetails[0]).containsText(('auto-import-fastboot.js'), 'Shows first asset name');
+    assert.dom(otherAssetsDetails[0]).containsText(('56.38 KB (16.47 KB gzipped)'), 'Shows first asset size');
+
+    assert.dom(otherAssetsDetails[1]).containsText(('chunk.js'), 'Shows second asset name');
+    assert.dom(otherAssetsDetails[1]).containsText(('56.38 KB (16.47 KB gzipped)'), 'Shows second asset size');
+
+    await click('.test-other-assets-toggle');
+
+    assert.dom('.test-other-assets-details').doesNotExist('Detail gone after collapsing');
+  });
+
+  test('toggling details resets other assets state', async function(assert) {
+    let addonSize = {
+      appJsSize: 1024,
+      appJsGzipSize: 400,
+
+      otherAssetsSize: 1836,
+      otherAssetsGzipSize: 1100,
+
+      totalJsSize: 3200,
+      totalJsGzipSize: 1500,
+
+      totalSize: 6000,
+      totalGzipSize: 2080,
+
+      normalizedOtherAssetFiles: [
+        {
+          name: 'auto-import-fastboot.js',
+          size: 57729,
+          gzipSize: 16869
+        },
+        {
+          name: 'chunk.js',
+          size: 57729,
+          gzipSize: 16869
+        },
+      ],
+
+      hasOtherAssetsFiles: true,
+    };
+
+    this.set('addonSize', addonSize);
+
+    await render(hbs`<DependencySize @addonSize={{addonSize}}/>`);
+
+    await click('.test-size-summary');
+    await click('.test-other-assets-toggle');
+    await click('.test-size-summary');
+    await click('.test-size-summary');
+
+    assert.dom('.test-other-assets-details').doesNotExist('Other assets state reset');
+  });
+});

--- a/tests/integration/helpers/format-bytes-test.js
+++ b/tests/integration/helpers/format-bytes-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | format-bytes', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders nothing if size is null', async function(assert) {
+    this.set('inputValue', null);
+
+    await render(hbs`{{format-bytes inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
+
+  test('it renders bytes', async function(assert) {
+    this.set('inputValue', '12');
+
+    await render(hbs`{{format-bytes inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '12 B');
+  });
+
+  test('it renders kilobytes', async function(assert) {
+    this.set('inputValue', '7785');
+
+    await render(hbs`{{format-bytes inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '7.6 KB');
+  });
+
+  test('it renders one kilobyte', async function(assert) {
+    this.set('inputValue', '1024');
+
+    await render(hbs`{{format-bytes inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1 KB');
+  });
+
+  test('it renders megabytes', async function(assert) {
+    this.set('inputValue', '2809565');
+
+    await render(hbs`{{format-bytes inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '2.68 MB');
+  });
+
+  test('it renders one megabyte', async function(assert) {
+    this.set('inputValue', '1048576');
+
+    await render(hbs`{{format-bytes inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1 MB');
+  });
+
+  test('it renders gigabytes', async function(assert) {
+    this.set('inputValue', '1095216660');
+
+    await render(hbs`{{format-bytes inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1.02 GB');
+  });
+
+  test('it renders one gigabyte', async function(assert) {
+    this.set('inputValue', '1073741824');
+
+    await render(hbs`{{format-bytes inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1 GB');
+  });
+});

--- a/tests/unit/utils/normalize-fingerprinted-asset-test.js
+++ b/tests/unit/utils/normalize-fingerprinted-asset-test.js
@@ -1,0 +1,17 @@
+import normalizeFingerprintedAsset from 'ember-observer/utils/normalize-fingerprinted-asset';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | normalize-fingerprinted-asset', function() {
+
+  test('strips fingerprint and path out of filename', function(assert) {
+    assert.equal(
+      normalizeFingerprintedAsset('dist/assets/auto-import-fastboot-b9d4d40d7911648425e44ca094c7de8d.js'),
+      'auto-import-fastboot.js'
+    );
+
+    assert.equal(
+      normalizeFingerprintedAsset('dist/assets/chunk.ffb692bd5eacbc9e936d.js'),
+      'chunk.js'
+    );
+  });
+});


### PR DESCRIPTION
Show addon dependency sizes (when available)

Requires server PR: https://github.com/emberobserver/server/pull/82

- Add package addon relationship to addon dependency

- When fetching dependencies, sideload addon size for the most recent version of the dependency

- Show total size next to dependency name; clicking expands to show details

- Clicking 'other assets' row expands to show filenames and sizes for files outside of app/vendor