### PR TITLE
Fix invisible no result label

### DIFF
--- a/app/styles/components/_large-search.scss
+++ b/app/styles/components/_large-search.scss
@@ -27,7 +27,7 @@
     }
 
     .no-results {
-      margin-top: 0.5rem 0;
+      margin: 0.5rem 0;
       visibility: hidden;
 
       &.showing {

--- a/app/styles/components/_large-search.scss
+++ b/app/styles/components/_large-search.scss
@@ -27,8 +27,7 @@
     }
 
     .no-results {
-      color: white;
-      margin-top: 0.5rem;
+      margin-top: 0.5rem 0;
       visibility: hidden;
 
       &.showing {


### PR DESCRIPTION
This PR is to fix the "no result" label that is invisible for the user
--Before--
<img width="404" alt="Screen Shot 2020-08-27 at 2 24 50 PM" src="https://user-images.githubusercontent.com/44621132/91477383-a9bfef80-e874-11ea-8a52-02a4184b1618.png">

--After--
<img width="407" alt="Screen Shot 2020-08-27 at 2 52 06 PM" src="https://user-images.githubusercontent.com/44621132/91477588-f0154e80-e874-11ea-9bfd-c4a9ad83e0a5.png">

