### PR TITLE
Adds new Ember observer logo to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You will need the following things properly installed on your computer.
 
 * `git clone <repository-url>` this repository
 * change into the new directory
-* `npm install`
+* `yarn install`
 
 ## Running / Development
 

--- a/app/components/page-layout.hbs
+++ b/app/components/page-layout.hbs
@@ -2,7 +2,7 @@
   <div class="main">
     <header class="navigation">
       <LinkTo @route="index" @query={{hash query=""}} class="name">
-        <img alt="telescope" src="/telescope.svg">
+        <img alt="" role="presentation" src="/ember-observer.svg">
         Ember Observer
       </LinkTo>
       {{#if this.showHeaderSearch}}

--- a/app/styles/components/_page-layout.scss
+++ b/app/styles/components/_page-layout.scss
@@ -40,19 +40,24 @@
       font-weight: 500;
       line-height: 1;
       white-space: nowrap;
-      display: block;
+      display: flex;
       margin-bottom: 1rem;
+      align-items: end;
 
       @include media($medium-screen) {
         margin-right: $default-spacing;
         margin-bottom: 0;
-        display: inline-block;
+        display: flex;
+        align-items: end;
       }
 
       img {
-        height: 2rem;
+        height: 3rem;
         vertical-align: middle;
-        margin-right: 0.5rem;
+        margin-right: 1rem;
+      }
+      p {
+        margin: 0;
       }
     }
 

--- a/app/styles/components/_page-layout.scss
+++ b/app/styles/components/_page-layout.scss
@@ -42,22 +42,17 @@
       white-space: nowrap;
       display: flex;
       margin-bottom: 1rem;
-      align-items: end;
+      align-items: flex-end;
 
       @include media($medium-screen) {
         margin-right: $default-spacing;
         margin-bottom: 0;
-        display: flex;
-        align-items: end;
       }
 
       img {
         height: 3rem;
         vertical-align: middle;
         margin-right: 1rem;
-      }
-      p {
-        margin: 0;
       }
     }
 

--- a/public/ember-observer.svg
+++ b/public/ember-observer.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 799 715" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g transform="matrix(1,0,0,1,-188.18,-408.513)">
+        <g transform="matrix(1,0,0,1,2.92964,-2.78569)">
+            <path d="M659.133,766.661C773.359,813.57 834.485,932.236 836.479,935.856" style="fill:none;stroke:rgb(179,204,217);stroke-width:22.38px;"/>
+        </g>
+        <g transform="matrix(0.750045,0,0,0.750045,332.868,59.6595)">
+            <path d="M656.307,765.017C770.533,811.926 842.938,930.789 844.726,935.367" style="fill:rgb(179,204,217);stroke:rgb(179,204,217);stroke-width:53.33px;"/>
+        </g>
+        <path d="M842.686,1122.95C846.93,1122.95 850.99,1121.22 853.935,1118.16C856.88,1115.11 858.456,1110.99 858.301,1106.75C850.498,912.715 703.461,758.007 523.216,758.007C343.327,758.007 196.515,912.104 188.193,1105.6C188.014,1110.13 189.689,1114.54 192.832,1117.81C195.975,1121.08 200.315,1122.93 204.851,1122.93C273.107,1122.95 523.216,1122.95 523.216,1122.95L842.686,1122.95ZM523.216,920.242C560.869,920.242 591.438,950.812 591.438,988.465C591.438,1026.12 560.869,1056.69 523.216,1056.69C485.563,1056.69 454.994,1026.12 454.994,988.465C454.994,950.812 485.563,920.242 523.216,920.242Z" style="fill:rgb(179,204,217);"/>
+        <g id="Layer2">
+            <path d="M630,513.967L696.693,513.989L725,514" style="fill:rgb(179,204,217);stroke:rgb(179,204,217);stroke-width:24px;"/>
+            <path d="M677.5,555.714L677.5,469.421" style="fill:rgb(179,204,217);stroke:rgb(179,204,217);stroke-width:24px;"/>
+        </g>
+        <g id="Layer21" serif:id="Layer2" transform="matrix(1,0,0,1,-251.37,150.636)">
+            <path d="M630,513.967L696.693,513.989L725,514" style="fill:rgb(179,204,217);stroke:rgb(179,204,217);stroke-width:24px;"/>
+            <path d="M677.5,555.714L677.5,469.421" style="fill:rgb(179,204,217);stroke:rgb(179,204,217);stroke-width:24px;"/>
+        </g>
+        <g id="Layer5">
+            <g transform="matrix(1,0,0,1,2.06142,1.62744)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+            <g transform="matrix(6.12323e-17,1,-1,6.12323e-17,1189.54,-161.516)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+            <g transform="matrix(1,0,0,1,-58.2623,-59.8897)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+            <g transform="matrix(6.12323e-17,1,-1,6.12323e-17,1249.87,-223.033)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+        </g>
+        <g id="Layer51" serif:id="Layer5" transform="matrix(1,0,0,1,-251.244,150.003)">
+            <g transform="matrix(1,0,0,1,2.06142,1.62744)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+            <g transform="matrix(6.12323e-17,1,-1,6.12323e-17,1189.54,-161.516)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+            <g transform="matrix(1,0,0,1,-58.2623,-59.8897)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+            <g transform="matrix(6.12323e-17,1,-1,6.12323e-17,1249.87,-223.033)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+        </g>
+        <g id="Layer52" serif:id="Layer5" transform="matrix(1,0,0,1,-423.253,-49.5404)">
+            <g transform="matrix(1,0,0,1,2.06142,1.62744)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+            <g transform="matrix(6.12323e-17,1,-1,6.12323e-17,1189.54,-161.516)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+            <g transform="matrix(1,0,0,1,-58.2623,-59.8897)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+            <g transform="matrix(6.12323e-17,1,-1,6.12323e-17,1249.87,-223.033)">
+                <path d="M698.304,534.126L712.645,550.537" style="fill:none;stroke:rgb(179,204,217);stroke-width:12px;"/>
+            </g>
+        </g>
+        <g id="Layer22" serif:id="Layer2" transform="matrix(1,0,0,1,-423.379,-48.9079)">
+            <path d="M630,513.967L696.693,513.989L725,514" style="fill:rgb(179,204,217);stroke:rgb(179,204,217);stroke-width:24px;"/>
+            <path d="M677.5,555.714L677.5,469.421" style="fill:rgb(179,204,217);stroke:rgb(179,204,217);stroke-width:24px;"/>
+        </g>
+        <g transform="matrix(0.789505,0,0,0.789505,162.927,169.592)">
+            <g id="Layer4">
+                <path d="M847.372,891.701L978.574,767.625C960.107,736.715 933.952,709.042 904.364,682.813C875.899,656.032 849.087,635.009 827.799,629.5L705.698,757.795C756.282,785.492 805.093,832.596 847.372,891.701Z" style="fill:rgb(179,204,217);stroke:rgb(179,204,217);stroke-width:10.13px;"/>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
In discussion with @kategengler I've created and added a new logo to the header :)

<img width="1066" alt="Screenshot 2020-10-06 at 19 46 24" src="https://user-images.githubusercontent.com/5811560/95240683-0ff14800-080d-11eb-88e5-5b273f3e709b.png">

PS: Also edited the readme to say yarn instead of nom :)
