### PR TITLE
Convert <AddonDetails/> into a template-only Glimmer component

### DIFF
--- a/app/components/addon-details.hbs
+++ b/app/components/addon-details.hbs
@@ -1,30 +1,32 @@
-{{#if this.showRanking}}
-  <span class="ranking">#{{this.addon.ranking}}</span>
-{{else}}
-  <ScoreDisplay @addon={{this.addon}} as |score|>
-    {{score}}
-  </ScoreDisplay>
-{{/if}}
-<div class="desc">
-  <LinkTo @route="addons.show" @model={{this.addon.name}} class="addon-link test-addon-name">
-    <span class="addon-name">
-      {{this.addon.name}}
-      {{#if this.addon.isDeprecated}}
-        <span class="notice">
-          (Deprecated)
-        </span>
+<div>
+  {{#if @showRanking}}
+    <span class="ranking">#{{@addon.ranking}}</span>
+  {{else}}
+    <ScoreDisplay @addon={{@addon}} as |score|>
+      {{score}}
+    </ScoreDisplay>
+  {{/if}}
+  <div class="desc">
+    <LinkTo @route="addons.show" @model={{@addon.name}} class="addon-link test-addon-name">
+      <span class="addon-name">
+        {{@addon.name}}
+        {{#if @addon.isDeprecated}}
+          <span class="notice">
+            (Deprecated)
+          </span>
+        {{/if}}
+      </span>
+      {{#if @addon.isOfficial}}
+        <OfficialIcon />
       {{/if}}
-    </span>
-    {{#if this.addon.isOfficial}}
-      <OfficialIcon />
-    {{/if}}
-    {{#if this.addon.isCliDependency}}
-      <DependencyIcon />
-    {{/if}}
-    <small>- {{this.addon.description}}</small>
-  </LinkTo>
-  <p>
-    <small><InlineCategoryList @categories={{this.addon.categories}} /></small>
-    <span class="last-updated">Last updated <RelativeTime @date={{this.addon.latestVersionDate}} /></span>
-  </p>
+      {{#if @addon.isCliDependency}}
+        <DependencyIcon />
+      {{/if}}
+      <small>- {{@addon.description}}</small>
+    </LinkTo>
+    <p>
+      <small><InlineCategoryList @categories={{@addon.categories}} /></small>
+      <span class="last-updated">Last updated <RelativeTime @date={{@addon.latestVersionDate}} /></span>
+    </p>
+  </div>
 </div>

--- a/app/components/addon-details.js
+++ b/app/components/addon-details.js
@@ -1,5 +1,0 @@
-import classic from 'ember-classic-decorator';
-import Component from '@ember/component';
-
-@classic
-export default class AddonDetails extends Component {}


### PR DESCRIPTION
Convert the `<AddonDetails />` component to be a template-only Glimmer component. This was an easy one since there was nothing actually happening on the backing class (other than the argument reflection).