### PR TITLE
Use static data in tests to avoid Percy showing changes that aren't meaningful

### DIFF
--- a/app/components/admin-addon.hbs
+++ b/app/components/admin-addon.hbs
@@ -88,7 +88,7 @@
   {{else}}
     <button type="button" class="button test-save-addon" {{action (perform this.saveAddon)}}>Save</button>
   {{/if}}
-  <div class="note">Last saved {{moment-from-now this.addon.updatedAt allowEmpty=true}} ({{moment-format this.addon.updatedAt "MMMM DD, YYYY h:mm:ss" allowEmpty=true}})</div>
+  <div class="note">Last saved <RelativeTime @date={{this.addon.updatedAt}} /> ({{moment-format this.addon.updatedAt "MMMM DD, YYYY h:mm:ss" allowEmpty=true}})</div>
 </section>
 
 <section class="latest-review">

--- a/app/components/relative-time.hbs
+++ b/app/components/relative-time.hbs
@@ -1,1 +1,3 @@
-{{moment-from-now this.date allowEmpty=true}}
+<time datetime={{this.isoDate}} title={{this.isoDate}}>
+  {{moment-from-now @date allowEmpty=true}}
+</time>

--- a/app/components/relative-time.hbs
+++ b/app/components/relative-time.hbs
@@ -1,3 +1,3 @@
 <time datetime={{this.isoDate}} title={{this.isoDate}}>
-  {{moment-from-now @date allowEmpty=true}}
+  {{moment-from @date this.currentDate.date allowEmpty=true}}
 </time>

--- a/app/components/relative-time.js
+++ b/app/components/relative-time.js
@@ -1,6 +1,9 @@
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class RelativeTime extends Component {
+  @service currentDate;
+
   get isoDate() {
     let date = this.args.date;
     return date ? date.toISOString() : null;

--- a/app/components/relative-time.js
+++ b/app/components/relative-time.js
@@ -1,17 +1,8 @@
-import classic from 'ember-classic-decorator';
-import { attributeBindings, tagName } from '@ember-decorators/component';
-import { computed } from '@ember/object';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
-@classic
-@tagName('time')
-@attributeBindings('isoDate:datetime', 'isoDate:title')
 export default class RelativeTime extends Component {
-  date = null;
-
-  @computed('date')
   get isoDate() {
-    let date = this.date;
+    let date = this.args.date;
     return date ? date.toISOString() : null;
   }
 }

--- a/app/routes/canary-test-results/index.js
+++ b/app/routes/canary-test-results/index.js
@@ -1,10 +1,11 @@
-import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import moment from 'moment';
 
-@classic
 export default class IndexRoute extends Route {
+  @service currentDate;
+
   beforeModel() {
-    this.transitionTo('canary-test-results.date', moment().format('YYYY-MM-DD'));
+    this.transitionTo('canary-test-results.date', moment(this.currentDate.date).format('YYYY-MM-DD'));
   }
 }

--- a/app/services/current-date.js
+++ b/app/services/current-date.js
@@ -1,7 +1,8 @@
 import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class CurrentDateService extends Service {
-  currentDateOverride = null;
+  @tracked currentDateOverride = null;
 
   get date() {
     return this.currentDateOverride || new Date();

--- a/app/services/current-date.js
+++ b/app/services/current-date.js
@@ -1,0 +1,13 @@
+import Service from '@ember/service';
+
+export default class CurrentDateService extends Service {
+  currentDateOverride = null;
+
+  get date() {
+    return this.currentDateOverride || new Date();
+  }
+
+  set date(date) {
+    this.currentDateOverride = date;
+  }
+}

--- a/app/services/current-date.js
+++ b/app/services/current-date.js
@@ -1,14 +1,7 @@
 import Service from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class CurrentDateService extends Service {
-  @tracked currentDateOverride = null;
-
   get date() {
-    return this.currentDateOverride || new Date();
-  }
-
-  set date(date) {
-    this.currentDateOverride = date;
+    return new Date();
   }
 }

--- a/tests/acceptance/addons-test.js
+++ b/tests/acceptance/addons-test.js
@@ -242,7 +242,8 @@ module('Acceptance: Addons', function(hooks) {
       hasTests: 1,
       hasReadme: 4,
       hasBuild: 1,
-      review: 'Seems ok'
+      review: 'Seems ok',
+      createdAt: '2020-10-31T17:14:51Z'
     });
 
     addonWithReview.latestReview = review;

--- a/tests/acceptance/admin-review-addon-test.js
+++ b/tests/acceptance/admin-review-addon-test.js
@@ -5,6 +5,7 @@ import {
   findAll,
   visit,
 } from '@ember/test-helpers';
+import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { percySnapshot } from 'ember-percy';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
@@ -84,7 +85,11 @@ module('Acceptance | admin review addon', function(hooks) {
 
     // fix "current date" so the relative date of the "last review" date
     // doesn't change and cause Percy to show a change when it shouldn't.
-    this.owner.lookup('service:current-date').date = moment('2020-10-31T17:14:51Z');
+    this.owner.register('service:current-date', class extends Service {
+      get date() {
+        return moment('2020-10-31T17:14:51Z');
+      }
+    });
 
     let newestAddonVersion = server.create('version', {
       addon,

--- a/tests/acceptance/admin-review-addon-test.js
+++ b/tests/acceptance/admin-review-addon-test.js
@@ -79,7 +79,12 @@ module('Acceptance | admin review addon', function(hooks) {
       hasBeenReviewed: true,
       repositoryUrl: 'http://example.com/fake-addon',
       demoUrl: 'http://example.org/demo',
+      updatedAt: '2020-10-01T17:14:51Z',
     });
+
+    // fix "current date" so the relative date of the "last review" date
+    // doesn't change and cause Percy to show a change when it shouldn't.
+    this.owner.lookup('service:current-date').date = moment('2020-10-31T17:14:51Z');
 
     let newestAddonVersion = server.create('version', {
       addon,

--- a/tests/acceptance/canary-test-results-test.js
+++ b/tests/acceptance/canary-test-results-test.js
@@ -7,6 +7,11 @@ import moment from 'moment';
 module('Acceptance | canary test results', function(hooks) {
   setupEmberObserverTest(hooks);
 
+  hooks.beforeEach(function() {
+    let currentDateService = this.owner.lookup('service:current-date');
+    currentDateService.date = moment('2020-10-31T17:14:51Z');
+  });
+
   test('redirects to current day', async function(assert) {
     let addon = server.create('addon');
 
@@ -14,8 +19,7 @@ module('Acceptance | canary test results', function(hooks) {
 
     server.create('testResult', {
       versionId: addonVersion.id,
-      canary: true,
-      createdAt: moment('2016-08-07 16:30').utc()
+      canary: true
     });
 
     await visit('/canary-test-results');

--- a/tests/acceptance/canary-test-results-test.js
+++ b/tests/acceptance/canary-test-results-test.js
@@ -1,4 +1,5 @@
 import { currentRouteName, visit } from '@ember/test-helpers';
+import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { percySnapshot } from 'ember-percy';
 import { setupEmberObserverTest } from '../helpers/setup-ember-observer-test';
@@ -8,8 +9,11 @@ module('Acceptance | canary test results', function(hooks) {
   setupEmberObserverTest(hooks);
 
   hooks.beforeEach(function() {
-    let currentDateService = this.owner.lookup('service:current-date');
-    currentDateService.date = moment('2020-10-31T17:14:51Z');
+    this.owner.register('service:current-date', class extends Service {
+      get date() {
+        return moment('2020-10-31T17:14:51Z');
+      }
+    });
   });
 
   test('redirects to current day', async function(assert) {

--- a/tests/acceptance/size-calculation-results-test.js
+++ b/tests/acceptance/size-calculation-results-test.js
@@ -111,6 +111,7 @@ module('Acceptance | size calculation results', function(hooks) {
     let testResult = server.create('sizeCalculationResult', {
       versionId: version.id,
       output: JSON.stringify(output),
+      testsRunAt: '2020-10-31T17:14:51Z',
     });
 
     await login();

--- a/tests/integration/components/relative-date-test.js
+++ b/tests/integration/components/relative-date-test.js
@@ -1,0 +1,49 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import moment from 'moment';
+
+module('Integration | Component | relative-date', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders as a <time> tag', async function(assert) {
+    await render(hbs`
+      <RelativeTime/>
+    `);
+
+    assert.dom('time').exists();
+  });
+
+  test('it displays the relative time from the given date', async function(assert) {
+    this.date = moment().subtract(3, 'days');
+
+    await render(hbs`
+      <RelativeTime @date={{this.date}} />
+    `);
+
+    assert.dom('time').hasText('3 days ago');
+  });
+
+  test('it uses the currentDate service to determine the current date', async function(assert) {
+    this.owner.lookup('service:current-date').date = moment('2020-10-30T00:00:00Z');
+
+    this.date = moment('2020-09-30T00:00:00Z');
+    await render(hbs`
+      <RelativeTime @date={{this.date}} />
+    `);
+
+    assert.dom('time').hasText('a month ago');
+  });
+
+  test('it sets the datetime and title attributes to the ISO-formatted date string', async function(assert) {
+    this.date = moment('2020-09-30T00:00:00Z');
+
+    await render(hbs`
+      <RelativeTime @date={{this.date}} />
+    `);
+
+    assert.dom('time').hasAttribute('datetime', '2020-09-30T00:00:00.000Z');
+    assert.dom('time').hasAttribute('title', '2020-09-30T00:00:00.000Z');
+  });
+});

--- a/tests/integration/components/relative-date-test.js
+++ b/tests/integration/components/relative-date-test.js
@@ -1,6 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import moment from 'moment';
 
@@ -26,9 +27,13 @@ module('Integration | Component | relative-date', function(hooks) {
   });
 
   test('it uses the currentDate service to determine the current date', async function(assert) {
-    this.owner.lookup('service:current-date').date = moment('2020-10-30T00:00:00Z');
+    this.owner.register('service:current-date', class extends Service {
+      get date() {
+        return moment('2006-10-30T00:00:00Z');
+      }
+    });
 
-    this.date = moment('2020-09-30T00:00:00Z');
+    this.date = moment('2006-09-30T00:00:00Z');
     await render(hbs`
       <RelativeTime @date={{this.date}} />
     `);


### PR DESCRIPTION
Fixes #146 

This PR makes some tests (a subset of the ones that include `percySnapshot` calls) to use static/fixed data to avoid showing visual changes just because of a different date.

There were two tests that couldn't be fixed just by using static data:
1) `Acceptance | admin review addon: Displays basic info about addon` - the `<AdminAddon/>` component used `{{moment-from-now}}` to display a relative interval (relative to the current date/time)
2) `Acceptance | canary test results: redirects to current day` - the redirection from `canary-test-results.index` to `canary-test-results.show` is based on the current date, which is rendered in the page

To get these to stop changing in Percy I added a `currentDate` service; its `date` property normally returns the actual current date, but a setter is provided to override this, and these tests make use of that.

As part of that change I modified the `<RelativeTime/>` component (the other place in the code we were using `{{moment-from-now}}` to also make use of this service. (I also converted this component to be a Glimmer component in the process.)